### PR TITLE
Hotfix: reference tuple

### DIFF
--- a/examples/simple/index.ts
+++ b/examples/simple/index.ts
@@ -11,7 +11,7 @@
 // }
 
 // export * from "./exported-functions";
-export { Kintamasis as Pakeistas } from "./exported-const-variables";
+// export { Kintamasis as Pakeistas } from "./exported-const-variables";
 // export type A<TValue> = number & { ok(): TValue };
 
 // Two types have a one common field
@@ -85,11 +85,11 @@ export { Kintamasis as Pakeistas } from "./exported-const-variables";
 //     Boos: string[];
 // }
 
-// export interface Foo<TType> {
-//     Name: string;
-//     Surname: string;
-//     Type: TType;
-// }
+export interface Foo<TType> {
+    Name: string;
+    Surname: string;
+    Type: TType;
+}
 
 // export interface Bar extends Foo<number>, Boo {
 //     OtherStuff: string[];

--- a/src/abstractions/api-callable-base.ts
+++ b/src/abstractions/api-callable-base.ts
@@ -4,7 +4,7 @@ import { ApiItem, ApiItemOptions } from "../abstractions/api-item";
 import { TSHelpers } from "../ts-helpers";
 import { ApiHelpers } from "../api-helpers";
 import { ApiFunctionDto } from "../contracts/definitions/api-function-dto";
-import { ApiItemReferenceDictionary } from "../contracts/api-item-reference-dictionary";
+import { ApiItemReferenceTuple } from "../contracts/api-item-reference-tuple";
 import { ApiItemKinds } from "../contracts/api-item-kinds";
 import { TypeDto } from "../contracts/type-dto";
 import { ApiMetadataDto } from "../contracts/api-metadata-dto";
@@ -19,8 +19,8 @@ export abstract class ApiCallableBase<
     >
     extends ApiItem<TDeclaration, TExtractDto> {
 
-    protected Parameters: ApiItemReferenceDictionary = {};
-    protected TypeParameters: ApiItemReferenceDictionary = {};
+    protected Parameters: ApiItemReferenceTuple = [];
+    protected TypeParameters: ApiItemReferenceTuple = [];
     protected ReturnType: TypeDto | undefined;
 
     protected OnGatherData(): void {

--- a/src/abstractions/api-item.ts
+++ b/src/abstractions/api-item.ts
@@ -10,7 +10,7 @@ export interface ApiItemOptions {
     Program: ts.Program;
     ExtractorOptions: ExtractorOptions;
     Registry: ReadonlyRegistry<ApiItem>;
-    AddItemToRegistry: (item: ApiItem) => string;
+    AddItemToRegistry(item: ApiItem): string;
 }
 
 export enum ApiItemStatus {

--- a/src/api-helpers.ts
+++ b/src/api-helpers.ts
@@ -4,7 +4,7 @@ import { LogLevel } from "simplr-logger";
 
 import { ApiItem, ApiItemOptions } from "./abstractions/api-item";
 
-import { ApiItemReferenceDictionary } from "./contracts/api-item-reference-dictionary";
+import { ApiItemReferenceTuple } from "./contracts/api-item-reference-tuple";
 import {
     TypeDto,
     TypeBasicDto,
@@ -121,8 +121,8 @@ export namespace ApiHelpers {
     export function GetItemsIdsFromSymbols(
         symbols: ts.UnderscoreEscapedMap<ts.Symbol> | undefined,
         options: ApiItemOptions
-    ): ApiItemReferenceDictionary {
-        const items: ApiItemReferenceDictionary = {};
+    ): ApiItemReferenceTuple {
+        const items: ApiItemReferenceTuple = {};
         if (symbols == null) {
             return items;
         }
@@ -163,8 +163,8 @@ export namespace ApiHelpers {
     export function GetItemsIdsFromDeclarations(
         declarations: ts.NodeArray<ts.Declaration>,
         options: ApiItemOptions
-    ): ApiItemReferenceDictionary {
-        const items: ApiItemReferenceDictionary = {};
+    ): ApiItemReferenceTuple {
+        const items: ApiItemReferenceTuple = {};
         const typeChecker = options.Program.getTypeChecker();
 
         declarations.forEach(declaration => {

--- a/src/api-helpers.ts
+++ b/src/api-helpers.ts
@@ -181,7 +181,7 @@ export namespace ApiHelpers {
             const index = items.findIndex(x => x != null && x.length === 2 && x[0] === symbol.name);
 
             if (index === -1) {
-                items[index] = [symbol.name, [itemId]];
+                items.push([symbol.name, [itemId]]);
             } else {
                 items[index][1].push(itemId);
             }

--- a/src/api-helpers.ts
+++ b/src/api-helpers.ts
@@ -111,14 +111,25 @@ export namespace ApiHelpers {
     }
 
     export function ShouldVisit(declaration: ts.Declaration, options: ApiItemOptions): boolean {
-        const declarationFileName = declaration.getSourceFile().fileName;
-        if (PathIsInside(declarationFileName, options.ExtractorOptions.ProjectDirectory)) {
-            return true;
+        const declarationSourceFile = declaration.getSourceFile();
+        const declarationFileName = declarationSourceFile.fileName;
+
+        if (!PathIsInside(declarationFileName, options.ExtractorOptions.ProjectDirectory)) {
+            return false;
         }
-        return false;
+
+        if (options.Program.isSourceFileFromExternalLibrary(declarationSourceFile)) {
+            return false;
+        }
+
+        return true;
     }
 
     export function GetItemId(declaration: ts.Declaration, symbol: ts.Symbol, options: ApiItemOptions): string | undefined {
+        if (!ShouldVisit(declaration, options)) {
+            return undefined;
+        }
+
         if (options.Registry.HasDeclaration(declaration)) {
             return options.Registry.GetDeclarationId(declaration);
         }

--- a/src/api-helpers.ts
+++ b/src/api-helpers.ts
@@ -118,11 +118,25 @@ export namespace ApiHelpers {
         return false;
     }
 
+    export function GetItemId(declaration: ts.Declaration, symbol: ts.Symbol, options: ApiItemOptions): string | undefined {
+        if (options.Registry.HasDeclaration(declaration)) {
+            return options.Registry.GetDeclarationId(declaration);
+        }
+
+        const resolveRealSymbol = TSHelpers.FollowSymbolAliases(symbol, options.Program.getTypeChecker());
+        const apiItem = VisitApiItem(declaration, resolveRealSymbol, options);
+        if (apiItem == null) {
+            return undefined;
+        }
+
+        return options.AddItemToRegistry(apiItem);
+    }
+
     export function GetItemsIdsFromSymbols(
         symbols: ts.UnderscoreEscapedMap<ts.Symbol> | undefined,
         options: ApiItemOptions
     ): ApiItemReferenceTuple {
-        const items: ApiItemReferenceTuple = {};
+        const items: ApiItemReferenceTuple = [];
         if (symbols == null) {
             return items;
         }
@@ -134,27 +148,13 @@ export namespace ApiHelpers {
             const symbolItems: string[] = [];
 
             symbol.declarations.forEach(declaration => {
-                // Check if declaration already exists in the registry.
-                if (options.Registry.HasDeclaration(declaration)) {
-                    const declarationId = options.Registry.GetDeclarationId(declaration);
-                    if (declarationId == null) {
-                        throw new Error(`Declaration id cannot be undefined.`);
-                    }
-                    symbolItems.push(declarationId);
-                    return;
+                const itemId = GetItemId(declaration, symbol, options);
+                if (itemId != null) {
+                    symbolItems.push(itemId);
                 }
-
-                const resolveRealSymbol = TSHelpers.FollowSymbolAliases(symbol, options.Program.getTypeChecker());
-
-                const visitedItem = VisitApiItem(declaration, resolveRealSymbol, options);
-                if (visitedItem == null || !ShouldVisit(declaration, options)) {
-                    return;
-                }
-
-                symbolItems.push(options.AddItemToRegistry(visitedItem));
             });
 
-            items[symbol.name] = symbolItems.length === 1 ? symbolItems.toString() : symbolItems;
+            items.push([symbol.name, symbolItems]);
         });
 
         return items;
@@ -164,7 +164,7 @@ export namespace ApiHelpers {
         declarations: ts.NodeArray<ts.Declaration>,
         options: ApiItemOptions
     ): ApiItemReferenceTuple {
-        const items: ApiItemReferenceTuple = {};
+        const items: ApiItemReferenceTuple = [];
         const typeChecker = options.Program.getTypeChecker();
 
         declarations.forEach(declaration => {
@@ -172,29 +172,18 @@ export namespace ApiHelpers {
             if (symbol == null) {
                 return;
             }
-            const name = symbol.name;
 
-            let declarationId = options.Registry.GetDeclarationId(declaration);
-            if (declarationId == null) {
-                const resolveRealSymbol = TSHelpers.FollowSymbolAliases(symbol, options.Program.getTypeChecker());
-
-                const visitedItem = VisitApiItem(declaration, resolveRealSymbol, options);
-                if (visitedItem == null || !ShouldVisit(declaration, options)) {
-                    return;
-                }
-
-                declarationId = options.AddItemToRegistry(visitedItem);
+            const itemId = GetItemId(declaration, symbol, options);
+            if (itemId == null) {
+                return;
             }
 
-            if (items[name] == null) {
-                items[name] = declarationId;
+            const index = items.findIndex(x => x != null && x.length === 2 && x[0] === symbol.name);
+
+            if (index === -1) {
+                items[index] = [symbol.name, [itemId]];
             } else {
-                const refs = items[name];
-                if (Array.isArray(refs)) {
-                    refs.push(declarationId);
-                } else {
-                    items[name] = [refs, declarationId];
-                }
+                items[index][1].push(itemId);
             }
         });
 

--- a/src/api-registry.ts
+++ b/src/api-registry.ts
@@ -2,9 +2,9 @@ import * as ts from "typescript";
 import { ApiItem } from "./abstractions/api-item";
 import { Dictionary } from "./contracts/dictionary";
 import { Registry } from "./contracts/registry";
-import { ApiBaseItemDto } from "./contracts/api-base-item-dto";
+import { ApiItemDto } from "./contracts/api-item-dto";
 
-export type ExtractedApiRegistry = Dictionary<ApiBaseItemDto>;
+export type ExtractedApiRegistry = Dictionary<ApiItemDto>;
 
 export class ApiRegistry implements Registry<ApiItem> {
     protected registry: Map<string, ApiItem> = new Map<string, ApiItem>();
@@ -21,7 +21,7 @@ export class ApiRegistry implements Registry<ApiItem> {
             const [key, apiItem] = item;
             const extractedData = apiItem.Extract(forceExtract);
 
-            this.ExtractedData[key] = extractedData;
+            this.ExtractedData[key] = extractedData as ApiItemDto;
         }
 
         this.IsDataExtracted = true;

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -2,7 +2,7 @@ export * from "./contracts/access-modifier";
 export * from "./contracts/api-base-item-dto";
 export * from "./contracts/api-callable-dto";
 export * from "./contracts/api-item-kinds";
-export * from "./contracts/api-item-reference-dictionary";
+export * from "./contracts/api-item-reference-tuple";
 export * from "./contracts/api-metadata-dto";
 export * from "./contracts/config";
 export * from "./contracts/definitions/api-call-dto";

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -33,3 +33,4 @@ export * from "./contracts/extractor-options";
 export * from "./contracts/registry";
 export * from "./contracts/type-dto";
 export * from "./contracts/type-kinds";
+export * from "./contracts/api-item-dto";

--- a/src/contracts/api-callable-dto.ts
+++ b/src/contracts/api-callable-dto.ts
@@ -1,10 +1,10 @@
 import { ApiBaseItemDto } from "./api-base-item-dto";
-import { ApiItemReferenceDictionary } from "./api-item-reference-dictionary";
+import { ApiItemReferenceTuple } from "./api-item-reference-tuple";
 import { TypeDto } from "./type-dto";
 import { ApiItemKinds } from "./api-item-kinds";
 
 export interface ApiCallableDto extends ApiBaseItemDto {
-    TypeParameters: ApiItemReferenceDictionary;
-    Parameters: ApiItemReferenceDictionary;
+    TypeParameters: ApiItemReferenceTuple;
+    Parameters: ApiItemReferenceTuple;
     ReturnType?: TypeDto;
 }

--- a/src/contracts/api-item-dto.ts
+++ b/src/contracts/api-item-dto.ts
@@ -1,0 +1,47 @@
+import { ApiCallDto } from "./definitions/api-call-dto";
+import { ApiClassConstructorDto } from "./definitions/api-class-constructor-dto";
+import { ApiClassDto } from "./definitions/api-class-dto";
+import { ApiClassMethodDto } from "./definitions/api-class-method-dto";
+import { ApiClassPropertyDto } from "./definitions/api-class-property-dto";
+import { ApiConstructDto } from "./definitions/api-construct-dto";
+import { ApiEnumDto } from "./definitions/api-enum-dto";
+import { ApiEnumMemberDto } from "./definitions/api-enum-member-dto";
+import { ApiExportDto } from "./definitions/api-export-dto";
+import { ApiExportSpecifierDto } from "./definitions/api-export-specifier-dto";
+import { ApiFunctionDto } from "./definitions/api-function-dto";
+import { ApiFunctionTypeDto } from "./definitions/api-function-type-dto";
+import { ApiIndexDto } from "./definitions/api-index-dto";
+import { ApiInterfaceDto } from "./definitions/api-interface-dto";
+import { ApiMethodDto } from "./definitions/api-method-dto";
+import { ApiNamespaceDto } from "./definitions/api-namespace-dto";
+import { ApiParameterDto } from "./definitions/api-parameter-dto";
+import { ApiPropertyDto } from "./definitions/api-property-dto";
+import { ApiSourceFileDto } from "./definitions/api-source-file-dto";
+import { ApiTypeDto } from "./definitions/api-type-dto";
+import { ApiTypeLiteralDto } from "./definitions/api-type-literal-dto";
+import { ApiTypeParameterDto } from "./definitions/api-type-parameter-dto";
+import { ApiVariableDto } from "./definitions/api-variable-dto";
+
+export type ApiItemDto = ApiCallDto |
+    ApiClassConstructorDto |
+    ApiClassDto |
+    ApiClassMethodDto |
+    ApiClassPropertyDto |
+    ApiConstructDto |
+    ApiEnumDto |
+    ApiEnumMemberDto |
+    ApiExportDto |
+    ApiExportSpecifierDto |
+    ApiFunctionDto |
+    ApiFunctionTypeDto |
+    ApiIndexDto |
+    ApiInterfaceDto |
+    ApiMethodDto |
+    ApiNamespaceDto |
+    ApiParameterDto |
+    ApiPropertyDto |
+    ApiSourceFileDto |
+    ApiTypeDto |
+    ApiTypeLiteralDto |
+    ApiTypeParameterDto |
+    ApiVariableDto;

--- a/src/contracts/api-item-reference-dictionary.ts
+++ b/src/contracts/api-item-reference-dictionary.ts
@@ -1,1 +1,0 @@
-export type ApiItemReferenceDictionary = { [key: string]: string | string[] };

--- a/src/contracts/api-item-reference-tuple.ts
+++ b/src/contracts/api-item-reference-tuple.ts
@@ -1,0 +1,1 @@
+export type ApiItemReferenceTuple = Array<[string, string[]]>;

--- a/src/contracts/definitions/api-class-constructor-dto.ts
+++ b/src/contracts/definitions/api-class-constructor-dto.ts
@@ -1,10 +1,10 @@
 import { ApiBaseItemDto } from "../api-base-item-dto";
 import { AccessModifier } from "../access-modifier";
-import { ApiItemReferenceDictionary } from "../api-item-reference-dictionary";
+import { ApiItemReferenceTuple } from "../api-item-reference-tuple";
 import { ApiItemKinds } from "../api-item-kinds";
 
 export interface ApiClassConstructorDto extends ApiBaseItemDto {
     ApiKind: ApiItemKinds.ClassConstructor;
-    Parameters: ApiItemReferenceDictionary;
+    Parameters: ApiItemReferenceTuple;
     AccessModifier: AccessModifier;
 }

--- a/src/contracts/definitions/api-class-dto.ts
+++ b/src/contracts/definitions/api-class-dto.ts
@@ -1,12 +1,12 @@
 import { ApiBaseItemDto } from "../api-base-item-dto";
-import { ApiItemReferenceDictionary } from "../api-item-reference-dictionary";
+import { ApiItemReferenceTuple } from "../api-item-reference-tuple";
 import { TypeDto } from "../type-dto";
 import { ApiItemKinds } from "../api-item-kinds";
 
 export interface ApiClassDto extends ApiBaseItemDto {
     ApiKind: ApiItemKinds.Class;
-    TypeParameters: ApiItemReferenceDictionary;
-    Members: ApiItemReferenceDictionary;
+    TypeParameters: ApiItemReferenceTuple;
+    Members: ApiItemReferenceTuple;
     Extends?: TypeDto;
     Implements: TypeDto[];
     IsAbstract: boolean;

--- a/src/contracts/definitions/api-construct-dto.ts
+++ b/src/contracts/definitions/api-construct-dto.ts
@@ -1,8 +1,8 @@
 import { ApiBaseItemDto } from "../api-base-item-dto";
-import { ApiItemReferenceDictionary } from "../api-item-reference-dictionary";
+import { ApiItemReferenceTuple } from "../api-item-reference-tuple";
 import { ApiItemKinds } from "../api-item-kinds";
 
 export interface ApiConstructDto extends ApiBaseItemDto {
     ApiKind: ApiItemKinds.Construct;
-    Parameters: ApiItemReferenceDictionary;
+    Parameters: ApiItemReferenceTuple;
 }

--- a/src/contracts/definitions/api-enum-dto.ts
+++ b/src/contracts/definitions/api-enum-dto.ts
@@ -1,8 +1,8 @@
 import { ApiBaseItemDto } from "../api-base-item-dto";
-import { ApiItemReferenceDictionary } from "../api-item-reference-dictionary";
+import { ApiItemReferenceTuple } from "../api-item-reference-tuple";
 import { ApiItemKinds } from "../api-item-kinds";
 
 export interface ApiEnumDto extends ApiBaseItemDto {
     ApiKind: ApiItemKinds.Enum;
-    Members: ApiItemReferenceDictionary;
+    Members: ApiItemReferenceTuple;
 }

--- a/src/contracts/definitions/api-export-dto.ts
+++ b/src/contracts/definitions/api-export-dto.ts
@@ -1,9 +1,9 @@
 import { ApiBaseItemDto } from "../api-base-item-dto";
-import { ApiItemReferenceDictionary } from "../api-item-reference-dictionary";
+import { ApiItemReferenceTuple } from "../api-item-reference-tuple";
 import { ApiItemKinds } from "../api-item-kinds";
 
 export interface ApiExportDto extends ApiBaseItemDto {
     ApiKind: ApiItemKinds.Export;
-    Members: ApiItemReferenceDictionary;
+    Members: ApiItemReferenceTuple;
     ExportPath: string;
 }

--- a/src/contracts/definitions/api-interface-dto.ts
+++ b/src/contracts/definitions/api-interface-dto.ts
@@ -1,11 +1,11 @@
 import { ApiBaseItemDto } from "../api-base-item-dto";
-import { ApiItemReferenceDictionary } from "../api-item-reference-dictionary";
+import { ApiItemReferenceTuple } from "../api-item-reference-tuple";
 import { TypeDto } from "../type-dto";
 import { ApiItemKinds } from "../api-item-kinds";
 
 export interface ApiInterfaceDto extends ApiBaseItemDto {
     ApiKind: ApiItemKinds.Interface;
-    TypeParameters: ApiItemReferenceDictionary;
-    Members: ApiItemReferenceDictionary;
+    TypeParameters: ApiItemReferenceTuple;
+    Members: ApiItemReferenceTuple;
     Extends: TypeDto[];
 }

--- a/src/contracts/definitions/api-namespace-dto.ts
+++ b/src/contracts/definitions/api-namespace-dto.ts
@@ -1,8 +1,8 @@
 import { ApiBaseItemDto } from "../api-base-item-dto";
-import { ApiItemReferenceDictionary } from "../api-item-reference-dictionary";
+import { ApiItemReferenceTuple } from "../api-item-reference-tuple";
 import { ApiItemKinds } from "../api-item-kinds";
 
 export interface ApiNamespaceDto extends ApiBaseItemDto {
     ApiKind: ApiItemKinds.Namespace;
-    Members: ApiItemReferenceDictionary;
+    Members: ApiItemReferenceTuple;
 }

--- a/src/contracts/definitions/api-source-file-dto.ts
+++ b/src/contracts/definitions/api-source-file-dto.ts
@@ -1,9 +1,9 @@
 import { ApiBaseItemDto } from "../api-base-item-dto";
-import { ApiItemReferenceDictionary } from "../api-item-reference-dictionary";
+import { ApiItemReferenceTuple } from "../api-item-reference-tuple";
 import { ApiItemKinds } from "../api-item-kinds";
 
 export interface ApiSourceFileDto extends ApiBaseItemDto {
     ApiKind: ApiItemKinds.SourceFile;
     Path: string;
-    Members: ApiItemReferenceDictionary;
+    Members: ApiItemReferenceTuple;
 }

--- a/src/contracts/definitions/api-type-dto.ts
+++ b/src/contracts/definitions/api-type-dto.ts
@@ -1,10 +1,10 @@
 import { ApiBaseItemDto } from "../api-base-item-dto";
 import { TypeDto } from "../type-dto";
-import { ApiItemReferenceDictionary } from "../api-item-reference-dictionary";
+import { ApiItemReferenceTuple } from "../api-item-reference-tuple";
 import { ApiItemKinds } from "../api-item-kinds";
 
 export interface ApiTypeDto extends ApiBaseItemDto {
     ApiKind: ApiItemKinds.Type;
-    TypeParameters: ApiItemReferenceDictionary;
+    TypeParameters: ApiItemReferenceTuple;
     Type: TypeDto;
 }

--- a/src/contracts/definitions/api-type-literal-dto.ts
+++ b/src/contracts/definitions/api-type-literal-dto.ts
@@ -1,8 +1,8 @@
 import { ApiBaseItemDto } from "../api-base-item-dto";
-import { ApiItemReferenceDictionary } from "../api-item-reference-dictionary";
+import { ApiItemReferenceTuple } from "../api-item-reference-tuple";
 import { ApiItemKinds } from "../api-item-kinds";
 
 export interface ApiTypeLiteralDto extends ApiBaseItemDto {
     ApiKind: ApiItemKinds.TypeLiteral;
-    Members: ApiItemReferenceDictionary;
+    Members: ApiItemReferenceTuple;
 }

--- a/src/definitions/api-call.ts
+++ b/src/definitions/api-call.ts
@@ -5,7 +5,7 @@ import { ApiParameter } from "./api-parameter";
 import { TSHelpers } from "../ts-helpers";
 import { ApiHelpers } from "../api-helpers";
 import { ApiCallDto } from "../contracts/definitions/api-call-dto";
-import { ApiItemReferenceDictionary } from "../contracts/api-item-reference-dictionary";
+import { ApiItemReferenceTuple } from "../contracts/api-item-reference-tuple";
 import { ApiItemKinds } from "../contracts/api-item-kinds";
 import { TypeDto } from "../contracts/type-dto";
 import { ApiMetadataDto } from "../contracts/api-metadata-dto";

--- a/src/definitions/api-class-constructor.ts
+++ b/src/definitions/api-class-constructor.ts
@@ -4,7 +4,7 @@ import { ApiItem, ApiItemOptions } from "../abstractions/api-item";
 import { TSHelpers } from "../ts-helpers";
 import { ApiHelpers } from "../api-helpers";
 import { ApiClassConstructorDto } from "../contracts/definitions/api-class-constructor-dto";
-import { ApiItemReferenceDictionary } from "../contracts/api-item-reference-dictionary";
+import { ApiItemReferenceTuple } from "../contracts/api-item-reference-tuple";
 import { ApiItemKinds } from "../contracts/api-item-kinds";
 import { AccessModifier } from "../contracts/access-modifier";
 import { TypeDto } from "../contracts/type-dto";
@@ -13,7 +13,7 @@ import { ApiParameter } from "./api-parameter";
 import { ApiMetadataDto } from "../contracts/api-metadata-dto";
 
 export class ApiClassConstructor extends ApiItem<ts.ConstructorDeclaration, ApiClassConstructorDto> {
-    private parameters: ApiItemReferenceDictionary = {};
+    private parameters: ApiItemReferenceTuple = [];
     private accessModifier: AccessModifier;
 
     protected OnGatherData(): void {

--- a/src/definitions/api-class-method.ts
+++ b/src/definitions/api-class-method.ts
@@ -4,7 +4,7 @@ import { ApiItem, ApiItemOptions } from "../abstractions/api-item";
 import { TSHelpers } from "../ts-helpers";
 import { ApiHelpers } from "../api-helpers";
 import { ApiClassMethodDto } from "../contracts/definitions/api-class-method-dto";
-import { ApiItemReferenceDictionary } from "../contracts/api-item-reference-dictionary";
+import { ApiItemReferenceTuple } from "../contracts/api-item-reference-tuple";
 import { ApiItemKinds } from "../contracts/api-item-kinds";
 import { AccessModifier } from "../contracts/access-modifier";
 import { TypeDto } from "../contracts/type-dto";

--- a/src/definitions/api-class.ts
+++ b/src/definitions/api-class.ts
@@ -4,7 +4,7 @@ import { ApiItem, ApiItemOptions } from "../abstractions/api-item";
 import { TSHelpers } from "../ts-helpers";
 import { ApiHelpers } from "../api-helpers";
 import { ApiClassDto } from "../contracts/definitions/api-class-dto";
-import { ApiItemReferenceDictionary } from "../contracts/api-item-reference-dictionary";
+import { ApiItemReferenceTuple } from "../contracts/api-item-reference-tuple";
 import { ApiItemKinds } from "../contracts/api-item-kinds";
 import { TypeDto } from "../contracts/type-dto";
 import { ApiMetadataDto } from "../contracts/api-metadata-dto";
@@ -15,8 +15,8 @@ export class ApiClass extends ApiItem<ts.ClassDeclaration, ApiClassDto> {
      */
     private extends: TypeDto | undefined;
     private implements: TypeDto[] = [];
-    private typeParameters: ApiItemReferenceDictionary = {};
-    private members: ApiItemReferenceDictionary = {};
+    private typeParameters: ApiItemReferenceTuple = [];
+    private members: ApiItemReferenceTuple = [];
     private isAbstract: boolean = false;
 
     protected OnGatherData(): void {

--- a/src/definitions/api-construct.ts
+++ b/src/definitions/api-construct.ts
@@ -4,7 +4,7 @@ import { ApiItem, ApiItemOptions } from "../abstractions/api-item";
 import { TSHelpers } from "../ts-helpers";
 import { ApiHelpers } from "../api-helpers";
 import { ApiConstructDto } from "../contracts/definitions/api-construct-dto";
-import { ApiItemReferenceDictionary } from "../contracts/api-item-reference-dictionary";
+import { ApiItemReferenceTuple } from "../contracts/api-item-reference-tuple";
 import { ApiItemKinds } from "../contracts/api-item-kinds";
 import { AccessModifier } from "../contracts/access-modifier";
 import { TypeDto } from "../contracts/type-dto";
@@ -13,7 +13,7 @@ import { ApiParameter } from "./api-parameter";
 import { ApiMetadataDto } from "../contracts/api-metadata-dto";
 
 export class ApiConstruct extends ApiItem<ts.ConstructSignatureDeclaration, ApiConstructDto> {
-    private parameters: ApiItemReferenceDictionary = {};
+    private parameters: ApiItemReferenceTuple = [];
 
     protected OnGatherData(): void {
         this.parameters = ApiHelpers.GetItemsIdsFromDeclarations(this.Declaration.parameters, this.Options);

--- a/src/definitions/api-enum.ts
+++ b/src/definitions/api-enum.ts
@@ -5,12 +5,12 @@ import { ApiEnumMember } from "./api-enum-member";
 import { TSHelpers } from "../ts-helpers";
 import { ApiHelpers } from "../api-helpers";
 import { ApiEnumDto } from "../contracts/definitions/api-enum-dto";
-import { ApiItemReferenceDictionary } from "../contracts/api-item-reference-dictionary";
+import { ApiItemReferenceTuple } from "../contracts/api-item-reference-tuple";
 import { ApiItemKinds } from "../contracts/api-item-kinds";
 import { ApiMetadataDto } from "../contracts/api-metadata-dto";
 
 export class ApiEnum extends ApiItem<ts.EnumDeclaration, ApiEnumDto> {
-    private members: ApiItemReferenceDictionary = {};
+    private members: ApiItemReferenceTuple = [];
 
     protected OnGatherData(): void {
         // Members

--- a/src/definitions/api-export-specifier.ts
+++ b/src/definitions/api-export-specifier.ts
@@ -1,8 +1,6 @@
 import * as ts from "typescript";
 import * as path from "path";
-import { LogLevel } from "simplr-logger";
 
-import { Logger } from "../utils/logger";
 import { ApiItem, ApiItemOptions } from "../abstractions/api-item";
 import { ApiSourceFile } from "./api-source-file";
 import { TSHelpers } from "../ts-helpers";
@@ -23,18 +21,17 @@ export class ApiExportSpecifier extends ApiItem<ts.ExportSpecifier, ApiExportSpe
         }
 
         this.targetSymbol.declarations.forEach(declaration => {
-            const declarationId = this.Options.Registry.GetDeclarationId(declaration);
-            if (declarationId != null) {
-                apiItems.push(declarationId);
+            const symbol = TSHelpers.GetSymbolFromDeclaration(declaration, this.TypeChecker);
+            if (symbol == null) {
                 return;
             }
 
-            const visitedItem = ApiHelpers.VisitApiItem(declaration, this.Symbol, this.Options);
-            if (visitedItem == null) {
+            const itemId = ApiHelpers.GetItemId(declaration, symbol, this.Options);
+            if (itemId == null) {
                 return;
             }
 
-            apiItems.push(this.Options.AddItemToRegistry(visitedItem));
+            apiItems.push(itemId);
         });
 
         return apiItems;

--- a/src/definitions/api-export.ts
+++ b/src/definitions/api-export.ts
@@ -8,7 +8,7 @@ import { ApiSourceFile } from "./api-source-file";
 import { TSHelpers } from "../ts-helpers";
 import { ApiHelpers } from "../api-helpers";
 import { ApiExportDto } from "../contracts/definitions/api-export-dto";
-import { ApiItemReferenceDictionary } from "../contracts/api-item-reference-dictionary";
+import { ApiItemReferenceTuple } from "../contracts/api-item-reference-tuple";
 import { ApiItemKinds } from "../contracts/api-item-kinds";
 import { TypeDto } from "../contracts/type-dto";
 import { ApiMetadataDto } from "../contracts/api-metadata-dto";
@@ -29,7 +29,7 @@ export class ApiExport extends ApiItem<ts.ExportDeclaration, ApiExportDto> {
             .join("/");
     }
 
-    private members: ApiItemReferenceDictionary = {};
+    private members: ApiItemReferenceTuple = [];
     private apiSourceFile: ApiSourceFile | undefined;
 
     protected OnGatherData(): void {

--- a/src/definitions/api-function-type.ts
+++ b/src/definitions/api-function-type.ts
@@ -5,7 +5,7 @@ import { ApiParameter } from "./api-parameter";
 import { TSHelpers } from "../ts-helpers";
 import { ApiHelpers } from "../api-helpers";
 import { ApiFunctionTypeDto } from "../contracts/definitions/api-function-type-dto";
-import { ApiItemReferenceDictionary } from "../contracts/api-item-reference-dictionary";
+import { ApiItemReferenceTuple } from "../contracts/api-item-reference-tuple";
 import { ApiItemKinds } from "../contracts/api-item-kinds";
 import { TypeDto } from "../contracts/type-dto";
 import { ApiMetadataDto } from "../contracts/api-metadata-dto";

--- a/src/definitions/api-function.ts
+++ b/src/definitions/api-function.ts
@@ -5,7 +5,7 @@ import { ApiParameter } from "./api-parameter";
 import { TSHelpers } from "../ts-helpers";
 import { ApiHelpers } from "../api-helpers";
 import { ApiFunctionDto } from "../contracts/definitions/api-function-dto";
-import { ApiItemReferenceDictionary } from "../contracts/api-item-reference-dictionary";
+import { ApiItemReferenceTuple } from "../contracts/api-item-reference-tuple";
 import { ApiItemKinds } from "../contracts/api-item-kinds";
 import { TypeDto } from "../contracts/type-dto";
 import { ApiMetadataDto } from "../contracts/api-metadata-dto";

--- a/src/definitions/api-index.ts
+++ b/src/definitions/api-index.ts
@@ -4,7 +4,7 @@ import { ApiItem, ApiItemOptions } from "../abstractions/api-item";
 import { TSHelpers } from "../ts-helpers";
 import { ApiHelpers } from "../api-helpers";
 import { ApiIndexDto } from "../contracts/definitions/api-index-dto";
-import { ApiItemReferenceDictionary } from "../contracts/api-item-reference-dictionary";
+import { ApiItemReferenceTuple } from "../contracts/api-item-reference-tuple";
 import { ApiItemKinds } from "../contracts/api-item-kinds";
 import { TypeDto } from "../contracts/type-dto";
 

--- a/src/definitions/api-index.ts
+++ b/src/definitions/api-index.ts
@@ -12,6 +12,7 @@ import { TypeDto } from "../contracts/type-dto";
 
 import { ApiParameter } from "./api-parameter";
 import { ApiMetadataDto } from "../contracts/api-metadata-dto";
+import { Logger } from "../utils/logger";
 
 export class ApiIndex extends ApiItem<ts.IndexSignatureDeclaration, ApiIndexDto> {
     private parameter: string;
@@ -20,9 +21,17 @@ export class ApiIndex extends ApiItem<ts.IndexSignatureDeclaration, ApiIndexDto>
     protected OnGatherData(): void {
         // Parameter
         const parameters = ApiHelpers.GetItemsIdsFromDeclarations(this.Declaration.parameters, this.Options);
+        Logger.Warn(JSON.stringify(parameters));
+
         if (parameters.length !== 1) {
             // This should not happen, because we run Semantic Diagnostics before extraction.
-            throw new Error("An index signature must have exactly one parameter.");
+            const message = `An index signature must have exactly one parameter, it has ${parameters.length}.`;
+            ApiHelpers.LogWithDeclarationPosition(
+                LogLevel.Error,
+                this.Declaration,
+                message
+            );
+            throw new Error(message);
         } else {
             const [name, references] = parameters[0];
 

--- a/src/definitions/api-index.ts
+++ b/src/definitions/api-index.ts
@@ -12,7 +12,6 @@ import { TypeDto } from "../contracts/type-dto";
 
 import { ApiParameter } from "./api-parameter";
 import { ApiMetadataDto } from "../contracts/api-metadata-dto";
-import { Logger } from "../utils/logger";
 
 export class ApiIndex extends ApiItem<ts.IndexSignatureDeclaration, ApiIndexDto> {
     private parameter: string;
@@ -21,7 +20,6 @@ export class ApiIndex extends ApiItem<ts.IndexSignatureDeclaration, ApiIndexDto>
     protected OnGatherData(): void {
         // Parameter
         const parameters = ApiHelpers.GetItemsIdsFromDeclarations(this.Declaration.parameters, this.Options);
-        Logger.Warn(JSON.stringify(parameters));
 
         if (parameters.length !== 1) {
             // This should not happen, because we run Semantic Diagnostics before extraction.

--- a/src/definitions/api-interface.ts
+++ b/src/definitions/api-interface.ts
@@ -4,7 +4,7 @@ import { ApiItem, ApiItemOptions } from "../abstractions/api-item";
 import { TSHelpers } from "../ts-helpers";
 import { ApiHelpers } from "../api-helpers";
 import { ApiInterfaceDto } from "../contracts/definitions/api-interface-dto";
-import { ApiItemReferenceDictionary } from "../contracts/api-item-reference-dictionary";
+import { ApiItemReferenceTuple } from "../contracts/api-item-reference-tuple";
 import { ApiItemKinds } from "../contracts/api-item-kinds";
 import { TypeDto } from "../contracts/type-dto";
 import { ApiMetadataDto } from "../contracts/api-metadata-dto";
@@ -14,8 +14,8 @@ export class ApiInterface extends ApiItem<ts.InterfaceDeclaration, ApiInterfaceD
      * Interfaces can extend multiple interfaces.
      */
     private extends: TypeDto[] = [];
-    private typeParameters: ApiItemReferenceDictionary = {};
-    private members: ApiItemReferenceDictionary = {};
+    private typeParameters: ApiItemReferenceTuple = [];
+    private members: ApiItemReferenceTuple = [];
 
     protected OnGatherData(): void {
         // Members

--- a/src/definitions/api-method.ts
+++ b/src/definitions/api-method.ts
@@ -4,7 +4,7 @@ import { ApiItem, ApiItemOptions } from "../abstractions/api-item";
 import { TSHelpers } from "../ts-helpers";
 import { ApiHelpers } from "../api-helpers";
 import { ApiMethodDto } from "../contracts/definitions/api-method-dto";
-import { ApiItemReferenceDictionary } from "../contracts/api-item-reference-dictionary";
+import { ApiItemReferenceTuple } from "../contracts/api-item-reference-tuple";
 import { ApiItemKinds } from "../contracts/api-item-kinds";
 import { TypeDto } from "../contracts/type-dto";
 

--- a/src/definitions/api-namespace.ts
+++ b/src/definitions/api-namespace.ts
@@ -4,12 +4,12 @@ import { ApiItem, ApiItemOptions } from "../abstractions/api-item";
 import { TSHelpers } from "../ts-helpers";
 import { ApiHelpers } from "../api-helpers";
 import { ApiNamespaceDto } from "../contracts/definitions/api-namespace-dto";
-import { ApiItemReferenceDictionary } from "../contracts/api-item-reference-dictionary";
+import { ApiItemReferenceTuple } from "../contracts/api-item-reference-tuple";
 import { ApiItemKinds } from "../contracts/api-item-kinds";
 import { ApiMetadataDto } from "../contracts/api-metadata-dto";
 
 export class ApiNamespace extends ApiItem<ts.ModuleDeclaration, ApiNamespaceDto> {
-    private members: ApiItemReferenceDictionary = {};
+    private members: ApiItemReferenceTuple = [];
 
     protected OnGatherData(): void {
         if (this.Symbol.exports == null) {

--- a/src/definitions/api-source-file.ts
+++ b/src/definitions/api-source-file.ts
@@ -4,7 +4,7 @@ import * as path from "path";
 import { ApiItem, ApiItemOptions } from "../abstractions/api-item";
 import { ApiSourceFileDto } from "../contracts/definitions/api-source-file-dto";
 import { ApiItemKinds } from "../contracts/api-item-kinds";
-import { ApiItemReferenceDictionary } from "../contracts/api-item-reference-dictionary";
+import { ApiItemReferenceTuple } from "../contracts/api-item-reference-tuple";
 import { TSHelpers } from "../ts-helpers";
 import { ApiHelpers } from "../api-helpers";
 
@@ -12,7 +12,7 @@ import { ApiVariable } from "./api-variable";
 import { ApiMetadataDto } from "../contracts/api-metadata-dto";
 
 export class ApiSourceFile extends ApiItem<ts.SourceFile, ApiSourceFileDto> {
-    private members: ApiItemReferenceDictionary;
+    private members: ApiItemReferenceTuple;
 
     private getFileName(): string {
         return path.basename(this.Declaration.fileName);

--- a/src/definitions/api-type-literal.ts
+++ b/src/definitions/api-type-literal.ts
@@ -8,10 +8,10 @@ import { ApiTypeLiteralDto } from "../contracts/definitions/api-type-literal-dto
 import { ApiItemKinds } from "../contracts/api-item-kinds";
 import { TypeDto } from "../contracts/type-dto";
 import { ApiMetadataDto } from "../contracts/api-metadata-dto";
-import { ApiItemReferenceDictionary } from "../contracts/api-item-reference-dictionary";
+import { ApiItemReferenceTuple } from "../contracts/api-item-reference-tuple";
 
 export class ApiTypeLiteral extends ApiItem<ts.TypeLiteralNode, ApiTypeLiteralDto> {
-    private members: ApiItemReferenceDictionary = {};
+    private members: ApiItemReferenceTuple = [];
 
     protected OnGatherData(): void {
         this.members = ApiHelpers.GetItemsIdsFromDeclarations(this.Declaration.members, this.Options);

--- a/src/definitions/api-type.ts
+++ b/src/definitions/api-type.ts
@@ -8,10 +8,10 @@ import { ApiTypeDto } from "../contracts/definitions/api-type-dto";
 import { ApiItemKinds } from "../contracts/api-item-kinds";
 import { TypeDto } from "../contracts/type-dto";
 import { ApiMetadataDto } from "../contracts/api-metadata-dto";
-import { ApiItemReferenceDictionary } from "../contracts/api-item-reference-dictionary";
+import { ApiItemReferenceTuple } from "../contracts/api-item-reference-tuple";
 
 export class ApiType extends ApiItem<ts.TypeAliasDeclaration, ApiTypeDto> {
-    private typeParameters: ApiItemReferenceDictionary = {};
+    private typeParameters: ApiItemReferenceTuple = [];
     private type: TypeDto;
 
     protected OnGatherData(): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export * from "./extractor";
 export * from "./api-helpers";
 export * from "./ts-helpers";
 export * from "./utils/tsconfig-json";
+export * from "./api-registry";
 
 import * as Contracts from "./contracts";
 export {

--- a/tests/cases/__tests__/__snapshots__/ClassDeclaration1.test.ts.snap
+++ b/tests/cases/__tests__/__snapshots__/ClassDeclaration1.test.ts.snap
@@ -7,9 +7,14 @@ Object {
       "ApiKind": "source-file",
       "Kind": 265,
       "KindString": "SourceFile",
-      "Members": Object {
-        "FooClass": "ClassDeclaration-0",
-      },
+      "Members": Array [
+        Array [
+          "FooClass",
+          Array [
+            "ClassDeclaration-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
@@ -26,15 +31,33 @@ Object {
       "IsAbstract": false,
       "Kind": 229,
       "KindString": "ClassDeclaration",
-      "Members": Object {
-        "BarProperty": "PropertyDeclaration-1",
-        "GetFoo": Array [
-          "MethodDeclaration-1",
-          "MethodDeclaration-2",
+      "Members": Array [
+        Array [
+          "SetFoo",
+          Array [
+            "MethodDeclaration-0",
+          ],
         ],
-        "IdProperty": "PropertyDeclaration-0",
-        "SetFoo": "MethodDeclaration-0",
-      },
+        Array [
+          "GetFoo",
+          Array [
+            "MethodDeclaration-1",
+            "MethodDeclaration-2",
+          ],
+        ],
+        Array [
+          "IdProperty",
+          Array [
+            "PropertyDeclaration-0",
+          ],
+        ],
+        Array [
+          "BarProperty",
+          Array [
+            "PropertyDeclaration-1",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [
           Object {
@@ -50,7 +73,7 @@ Object {
         ],
       },
       "Name": "FooClass",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "MethodDeclaration-0": Object {
       "AccessModifier": "protected",
@@ -70,9 +93,14 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "SetFoo",
-      "Parameters": Object {
-        "foo": "Parameter-0",
-      },
+      "Parameters": Array [
+        Array [
+          "foo",
+          Array [
+            "Parameter-0",
+          ],
+        ],
+      ],
       "ReturnType": Object {
         "ApiTypeKind": "basic",
         "Flags": 1024,
@@ -81,7 +109,7 @@ Object {
         "Name": undefined,
         "Text": "void",
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "MethodDeclaration-1": Object {
       "AccessModifier": "public",
@@ -110,9 +138,14 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "GetFoo",
-      "Parameters": Object {
-        "a": "Parameter-1",
-      },
+      "Parameters": Array [
+        Array [
+          "a",
+          Array [
+            "Parameter-1",
+          ],
+        ],
+      ],
       "ReturnType": Object {
         "ApiTypeKind": "basic",
         "Flags": 2,
@@ -121,7 +154,7 @@ Object {
         "Name": undefined,
         "Text": "string",
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "MethodDeclaration-2": Object {
       "AccessModifier": "public",
@@ -150,7 +183,7 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "GetFoo",
-      "Parameters": Object {},
+      "Parameters": Array [],
       "ReturnType": Object {
         "ApiTypeKind": "basic",
         "Flags": 2,
@@ -159,7 +192,7 @@ Object {
         "Name": undefined,
         "Text": "string",
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "Parameter-0": Object {
       "ApiKind": "parameter",

--- a/tests/cases/__tests__/__snapshots__/ClassDeclaration2.test.ts.snap
+++ b/tests/cases/__tests__/__snapshots__/ClassDeclaration2.test.ts.snap
@@ -7,9 +7,14 @@ Object {
       "ApiKind": "source-file",
       "Kind": 265,
       "KindString": "SourceFile",
-      "Members": Object {
-        "Foo": "ClassDeclaration-0",
-      },
+      "Members": Array [
+        Array [
+          "Foo",
+          Array [
+            "ClassDeclaration-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
@@ -26,18 +31,38 @@ Object {
       "IsAbstract": true,
       "Kind": 229,
       "KindString": "ClassDeclaration",
-      "Members": Object {
-        "Bar": "PropertyDeclaration-1",
-        "GetFoo": "MethodDeclaration-1",
-        "Id": "PropertyDeclaration-0",
-        "SetFoo": "MethodDeclaration-0",
-      },
+      "Members": Array [
+        Array [
+          "SetFoo",
+          Array [
+            "MethodDeclaration-0",
+          ],
+        ],
+        Array [
+          "GetFoo",
+          Array [
+            "MethodDeclaration-1",
+          ],
+        ],
+        Array [
+          "Id",
+          Array [
+            "PropertyDeclaration-0",
+          ],
+        ],
+        Array [
+          "Bar",
+          Array [
+            "PropertyDeclaration-1",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "Foo",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "MethodDeclaration-0": Object {
       "AccessModifier": "protected",
@@ -52,9 +77,14 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "SetFoo",
-      "Parameters": Object {
-        "foo": "Parameter-0",
-      },
+      "Parameters": Array [
+        Array [
+          "foo",
+          Array [
+            "Parameter-0",
+          ],
+        ],
+      ],
       "ReturnType": Object {
         "ApiTypeKind": "basic",
         "Flags": 1024,
@@ -63,7 +93,7 @@ Object {
         "Name": undefined,
         "Text": "void",
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "MethodDeclaration-1": Object {
       "AccessModifier": "public",
@@ -78,7 +108,7 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "GetFoo",
-      "Parameters": Object {},
+      "Parameters": Array [],
       "ReturnType": Object {
         "ApiTypeKind": "basic",
         "Flags": 2,
@@ -87,7 +117,7 @@ Object {
         "Name": undefined,
         "Text": "string",
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "Parameter-0": Object {
       "ApiKind": "parameter",

--- a/tests/cases/__tests__/__snapshots__/ClassDeclaration3.test.ts.snap
+++ b/tests/cases/__tests__/__snapshots__/ClassDeclaration3.test.ts.snap
@@ -7,10 +7,20 @@ Object {
       "ApiKind": "source-file",
       "Kind": 265,
       "KindString": "SourceFile",
-      "Members": Object {
-        "Foo": "InterfaceDeclaration-0",
-        "FooClass": "ClassDeclaration-0",
-      },
+      "Members": Array [
+        Array [
+          "Foo",
+          Array [
+            "InterfaceDeclaration-0",
+          ],
+        ],
+        Array [
+          "FooClass",
+          Array [
+            "ClassDeclaration-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
@@ -35,30 +45,40 @@ Object {
       "IsAbstract": false,
       "Kind": 229,
       "KindString": "ClassDeclaration",
-      "Members": Object {
-        "Bar": "PropertyDeclaration-0",
-      },
+      "Members": Array [
+        Array [
+          "Bar",
+          Array [
+            "PropertyDeclaration-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "FooClass",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "InterfaceDeclaration-0": Object {
       "ApiKind": "interface",
       "Extends": Array [],
       "Kind": 230,
       "KindString": "InterfaceDeclaration",
-      "Members": Object {
-        "Bar": "PropertySignature-0",
-      },
+      "Members": Array [
+        Array [
+          "Bar",
+          Array [
+            "PropertySignature-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "Foo",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "PropertyDeclaration-0": Object {
       "AccessModifier": "public",

--- a/tests/cases/__tests__/__snapshots__/ClassDeclaration4.test.ts.snap
+++ b/tests/cases/__tests__/__snapshots__/ClassDeclaration4.test.ts.snap
@@ -7,11 +7,26 @@ Object {
       "ApiKind": "source-file",
       "Kind": 265,
       "KindString": "SourceFile",
-      "Members": Object {
-        "Foo": "InterfaceDeclaration-0",
-        "Foo2": "InterfaceDeclaration-1",
-        "FooClass": "ClassDeclaration-0",
-      },
+      "Members": Array [
+        Array [
+          "Foo",
+          Array [
+            "InterfaceDeclaration-0",
+          ],
+        ],
+        Array [
+          "Foo2",
+          Array [
+            "InterfaceDeclaration-1",
+          ],
+        ],
+        Array [
+          "FooClass",
+          Array [
+            "ClassDeclaration-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
@@ -43,46 +58,66 @@ Object {
       "IsAbstract": false,
       "Kind": 229,
       "KindString": "ClassDeclaration",
-      "Members": Object {
-        "Bar": "PropertyDeclaration-0",
-        "Bar2": "PropertyDeclaration-1",
-      },
+      "Members": Array [
+        Array [
+          "Bar",
+          Array [
+            "PropertyDeclaration-0",
+          ],
+        ],
+        Array [
+          "Bar2",
+          Array [
+            "PropertyDeclaration-1",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "FooClass",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "InterfaceDeclaration-0": Object {
       "ApiKind": "interface",
       "Extends": Array [],
       "Kind": 230,
       "KindString": "InterfaceDeclaration",
-      "Members": Object {
-        "Bar": "PropertySignature-0",
-      },
+      "Members": Array [
+        Array [
+          "Bar",
+          Array [
+            "PropertySignature-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "Foo",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "InterfaceDeclaration-1": Object {
       "ApiKind": "interface",
       "Extends": Array [],
       "Kind": 230,
       "KindString": "InterfaceDeclaration",
-      "Members": Object {
-        "Bar2": "PropertySignature-1",
-      },
+      "Members": Array [
+        Array [
+          "Bar2",
+          Array [
+            "PropertySignature-1",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "Foo2",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "PropertyDeclaration-0": Object {
       "AccessModifier": "public",

--- a/tests/cases/__tests__/__snapshots__/ClassDeclaration5.test.ts.snap
+++ b/tests/cases/__tests__/__snapshots__/ClassDeclaration5.test.ts.snap
@@ -7,10 +7,20 @@ Object {
       "ApiKind": "source-file",
       "Kind": 265,
       "KindString": "SourceFile",
-      "Members": Object {
-        "Foo": "ClassDeclaration-1",
-        "FooBase": "ClassDeclaration-0",
-      },
+      "Members": Array [
+        Array [
+          "FooBase",
+          Array [
+            "ClassDeclaration-0",
+          ],
+        ],
+        Array [
+          "Foo",
+          Array [
+            "ClassDeclaration-1",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
@@ -27,17 +37,27 @@ Object {
       "IsAbstract": true,
       "Kind": 229,
       "KindString": "ClassDeclaration",
-      "Members": Object {
-        "GetValue": "MethodDeclaration-0",
-      },
+      "Members": Array [
+        Array [
+          "GetValue",
+          Array [
+            "MethodDeclaration-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "FooBase",
-      "TypeParameters": Object {
-        "TValue": "TypeParameter-0",
-      },
+      "TypeParameters": Array [
+        Array [
+          "TValue",
+          Array [
+            "TypeParameter-0",
+          ],
+        ],
+      ],
     },
     "ClassDeclaration-1": Object {
       "ApiKind": "class",
@@ -61,15 +81,20 @@ Object {
       "IsAbstract": false,
       "Kind": 229,
       "KindString": "ClassDeclaration",
-      "Members": Object {
-        "GetValue": "MethodDeclaration-1",
-      },
+      "Members": Array [
+        Array [
+          "GetValue",
+          Array [
+            "MethodDeclaration-1",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "Foo",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "MethodDeclaration-0": Object {
       "AccessModifier": "public",
@@ -84,7 +109,7 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "GetValue",
-      "Parameters": Object {},
+      "Parameters": Array [],
       "ReturnType": Object {
         "ApiTypeKind": "reference",
         "Generics": undefined,
@@ -92,7 +117,7 @@ Object {
         "ReferenceId": "TypeParameter-0",
         "Text": "TValue",
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "MethodDeclaration-1": Object {
       "AccessModifier": "public",
@@ -107,7 +132,7 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "GetValue",
-      "Parameters": Object {},
+      "Parameters": Array [],
       "ReturnType": Object {
         "ApiTypeKind": "basic",
         "Flags": 4,
@@ -116,7 +141,7 @@ Object {
         "Name": undefined,
         "Text": "number",
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "TypeParameter-0": Object {
       "ApiKind": "type-parameter",

--- a/tests/cases/__tests__/__snapshots__/ClassDeclaration6.test.ts.snap
+++ b/tests/cases/__tests__/__snapshots__/ClassDeclaration6.test.ts.snap
@@ -7,11 +7,26 @@ Object {
       "ApiKind": "source-file",
       "Kind": 265,
       "KindString": "SourceFile",
-      "Members": Object {
-        "Bar": "InterfaceDeclaration-0",
-        "Foo": "ClassDeclaration-1",
-        "FooBase": "ClassDeclaration-0",
-      },
+      "Members": Array [
+        Array [
+          "FooBase",
+          Array [
+            "ClassDeclaration-0",
+          ],
+        ],
+        Array [
+          "Bar",
+          Array [
+            "InterfaceDeclaration-0",
+          ],
+        ],
+        Array [
+          "Foo",
+          Array [
+            "ClassDeclaration-1",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
@@ -28,17 +43,27 @@ Object {
       "IsAbstract": true,
       "Kind": 229,
       "KindString": "ClassDeclaration",
-      "Members": Object {
-        "GetValue": "MethodDeclaration-0",
-      },
+      "Members": Array [
+        Array [
+          "GetValue",
+          Array [
+            "MethodDeclaration-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "FooBase",
-      "TypeParameters": Object {
-        "TValue": "TypeParameter-0",
-      },
+      "TypeParameters": Array [
+        Array [
+          "TValue",
+          Array [
+            "TypeParameter-0",
+          ],
+        ],
+      ],
     },
     "ClassDeclaration-1": Object {
       "ApiKind": "class",
@@ -70,31 +95,46 @@ Object {
       "IsAbstract": false,
       "Kind": 229,
       "KindString": "ClassDeclaration",
-      "Members": Object {
-        "BarName": "PropertyDeclaration-0",
-        "GetValue": "MethodDeclaration-1",
-      },
+      "Members": Array [
+        Array [
+          "GetValue",
+          Array [
+            "MethodDeclaration-1",
+          ],
+        ],
+        Array [
+          "BarName",
+          Array [
+            "PropertyDeclaration-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "Foo",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "InterfaceDeclaration-0": Object {
       "ApiKind": "interface",
       "Extends": Array [],
       "Kind": 230,
       "KindString": "InterfaceDeclaration",
-      "Members": Object {
-        "BarName": "PropertySignature-0",
-      },
+      "Members": Array [
+        Array [
+          "BarName",
+          Array [
+            "PropertySignature-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "Bar",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "MethodDeclaration-0": Object {
       "AccessModifier": "public",
@@ -109,7 +149,7 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "GetValue",
-      "Parameters": Object {},
+      "Parameters": Array [],
       "ReturnType": Object {
         "ApiTypeKind": "reference",
         "Generics": undefined,
@@ -117,7 +157,7 @@ Object {
         "ReferenceId": "TypeParameter-0",
         "Text": "TValue",
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "MethodDeclaration-1": Object {
       "AccessModifier": "public",
@@ -132,7 +172,7 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "GetValue",
-      "Parameters": Object {},
+      "Parameters": Array [],
       "ReturnType": Object {
         "ApiTypeKind": "basic",
         "Flags": 4,
@@ -141,7 +181,7 @@ Object {
         "Name": undefined,
         "Text": "number",
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "PropertyDeclaration-0": Object {
       "AccessModifier": "public",

--- a/tests/cases/__tests__/__snapshots__/ClassDeclaration7.test.ts.snap
+++ b/tests/cases/__tests__/__snapshots__/ClassDeclaration7.test.ts.snap
@@ -7,9 +7,14 @@ Object {
       "ApiKind": "source-file",
       "Kind": 265,
       "KindString": "SourceFile",
-      "Members": Object {
-        "FooClass": "ClassDeclaration-0",
-      },
+      "Members": Array [
+        Array [
+          "FooClass",
+          Array [
+            "ClassDeclaration-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
@@ -26,15 +31,20 @@ Object {
       "IsAbstract": false,
       "Kind": 229,
       "KindString": "ClassDeclaration",
-      "Members": Object {},
+      "Members": Array [],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "FooClass",
-      "TypeParameters": Object {
-        "TValue": "TypeParameter-0",
-      },
+      "TypeParameters": Array [
+        Array [
+          "TValue",
+          Array [
+            "TypeParameter-0",
+          ],
+        ],
+      ],
     },
     "TypeParameter-0": Object {
       "ApiKind": "type-parameter",

--- a/tests/cases/__tests__/__snapshots__/ClassDeclaration8.test.ts.snap
+++ b/tests/cases/__tests__/__snapshots__/ClassDeclaration8.test.ts.snap
@@ -7,11 +7,26 @@ Object {
       "ApiKind": "source-file",
       "Kind": 265,
       "KindString": "SourceFile",
-      "Members": Object {
-        "Button": "ClassDeclaration-1",
-        "Control": "ClassDeclaration-0",
-        "SelectableControl": "InterfaceDeclaration-0",
-      },
+      "Members": Array [
+        Array [
+          "Control",
+          Array [
+            "ClassDeclaration-0",
+          ],
+        ],
+        Array [
+          "SelectableControl",
+          Array [
+            "InterfaceDeclaration-0",
+          ],
+        ],
+        Array [
+          "Button",
+          Array [
+            "ClassDeclaration-1",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
@@ -28,15 +43,20 @@ Object {
       "IsAbstract": false,
       "Kind": 229,
       "KindString": "ClassDeclaration",
-      "Members": Object {
-        "state": "PropertyDeclaration-0",
-      },
+      "Members": Array [
+        Array [
+          "state",
+          Array [
+            "PropertyDeclaration-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "Control",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "ClassDeclaration-1": Object {
       "ApiKind": "class",
@@ -59,15 +79,20 @@ Object {
       "IsAbstract": false,
       "Kind": 229,
       "KindString": "ClassDeclaration",
-      "Members": Object {
-        "select": "MethodDeclaration-0",
-      },
+      "Members": Array [
+        Array [
+          "select",
+          Array [
+            "MethodDeclaration-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "Button",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "InterfaceDeclaration-0": Object {
       "ApiKind": "interface",
@@ -82,15 +107,20 @@ Object {
       ],
       "Kind": 230,
       "KindString": "InterfaceDeclaration",
-      "Members": Object {
-        "select": "MethodSignature-0",
-      },
+      "Members": Array [
+        Array [
+          "select",
+          Array [
+            "MethodSignature-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "SelectableControl",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "MethodDeclaration-0": Object {
       "AccessModifier": "public",
@@ -105,7 +135,7 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "select",
-      "Parameters": Object {},
+      "Parameters": Array [],
       "ReturnType": Object {
         "ApiTypeKind": "basic",
         "Flags": 1024,
@@ -114,7 +144,7 @@ Object {
         "Name": undefined,
         "Text": "void",
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "MethodSignature-0": Object {
       "ApiKind": "method",
@@ -126,7 +156,7 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "select",
-      "Parameters": Object {},
+      "Parameters": Array [],
       "ReturnType": Object {
         "ApiTypeKind": "basic",
         "Flags": 1024,
@@ -135,7 +165,7 @@ Object {
         "Name": undefined,
         "Text": "void",
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "PropertyDeclaration-0": Object {
       "AccessModifier": "private",

--- a/tests/cases/__tests__/__snapshots__/ClassDeclaration9.test.ts.snap
+++ b/tests/cases/__tests__/__snapshots__/ClassDeclaration9.test.ts.snap
@@ -7,10 +7,20 @@ Object {
       "ApiKind": "source-file",
       "Kind": 265,
       "KindString": "SourceFile",
-      "Members": Object {
-        "Point": "ClassDeclaration-0",
-        "Point3d": "ClassDeclaration-1",
-      },
+      "Members": Array [
+        Array [
+          "Point",
+          Array [
+            "ClassDeclaration-0",
+          ],
+        ],
+        Array [
+          "Point3d",
+          Array [
+            "ClassDeclaration-1",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
@@ -27,16 +37,26 @@ Object {
       "IsAbstract": false,
       "Kind": 229,
       "KindString": "ClassDeclaration",
-      "Members": Object {
-        "x": "PropertyDeclaration-0",
-        "y": "PropertyDeclaration-1",
-      },
+      "Members": Array [
+        Array [
+          "x",
+          Array [
+            "PropertyDeclaration-0",
+          ],
+        ],
+        Array [
+          "y",
+          Array [
+            "PropertyDeclaration-1",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "Point",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "ClassDeclaration-1": Object {
       "ApiKind": "class",
@@ -53,17 +73,32 @@ Object {
       "IsAbstract": false,
       "Kind": 229,
       "KindString": "ClassDeclaration",
-      "Members": Object {
-        "x": "PropertyDeclaration-2",
-        "y": "PropertyDeclaration-3",
-        "z": "PropertyDeclaration-4",
-      },
+      "Members": Array [
+        Array [
+          "x",
+          Array [
+            "PropertyDeclaration-2",
+          ],
+        ],
+        Array [
+          "y",
+          Array [
+            "PropertyDeclaration-3",
+          ],
+        ],
+        Array [
+          "z",
+          Array [
+            "PropertyDeclaration-4",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "Point3d",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "PropertyDeclaration-0": Object {
       "AccessModifier": "public",

--- a/tests/cases/__tests__/__snapshots__/ExportDeclaration1.test.ts.snap
+++ b/tests/cases/__tests__/__snapshots__/ExportDeclaration1.test.ts.snap
@@ -7,9 +7,14 @@ Object {
       "ApiKind": "source-file",
       "Kind": 265,
       "KindString": "SourceFile",
-      "Members": Object {
-        "__export": "ExportDeclaration-0",
-      },
+      "Members": Array [
+        Array [
+          "__export",
+          Array [
+            "ExportDeclaration-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
@@ -26,15 +31,33 @@ Object {
       "IsAbstract": false,
       "Kind": 229,
       "KindString": "ClassDeclaration",
-      "Members": Object {
-        "BarProperty": "PropertyDeclaration-1",
-        "GetFoo": Array [
-          "MethodDeclaration-1",
-          "MethodDeclaration-2",
+      "Members": Array [
+        Array [
+          "SetFoo",
+          Array [
+            "MethodDeclaration-0",
+          ],
         ],
-        "IdProperty": "PropertyDeclaration-0",
-        "SetFoo": "MethodDeclaration-0",
-      },
+        Array [
+          "GetFoo",
+          Array [
+            "MethodDeclaration-1",
+            "MethodDeclaration-2",
+          ],
+        ],
+        Array [
+          "IdProperty",
+          Array [
+            "PropertyDeclaration-0",
+          ],
+        ],
+        Array [
+          "BarProperty",
+          Array [
+            "PropertyDeclaration-1",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [
           Object {
@@ -50,16 +73,21 @@ Object {
         ],
       },
       "Name": "FooClass",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "ExportDeclaration-0": Object {
       "ApiKind": "export",
       "ExportPath": "cases/ClassDeclaration1.ts",
       "Kind": 244,
       "KindString": "ExportDeclaration",
-      "Members": Object {
-        "FooClass": "ClassDeclaration-0",
-      },
+      "Members": Array [
+        Array [
+          "FooClass",
+          Array [
+            "ClassDeclaration-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
@@ -84,9 +112,14 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "SetFoo",
-      "Parameters": Object {
-        "foo": "Parameter-0",
-      },
+      "Parameters": Array [
+        Array [
+          "foo",
+          Array [
+            "Parameter-0",
+          ],
+        ],
+      ],
       "ReturnType": Object {
         "ApiTypeKind": "basic",
         "Flags": 1024,
@@ -95,7 +128,7 @@ Object {
         "Name": undefined,
         "Text": "void",
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "MethodDeclaration-1": Object {
       "AccessModifier": "public",
@@ -124,9 +157,14 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "GetFoo",
-      "Parameters": Object {
-        "a": "Parameter-1",
-      },
+      "Parameters": Array [
+        Array [
+          "a",
+          Array [
+            "Parameter-1",
+          ],
+        ],
+      ],
       "ReturnType": Object {
         "ApiTypeKind": "basic",
         "Flags": 2,
@@ -135,7 +173,7 @@ Object {
         "Name": undefined,
         "Text": "string",
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "MethodDeclaration-2": Object {
       "AccessModifier": "public",
@@ -164,7 +202,7 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "GetFoo",
-      "Parameters": Object {},
+      "Parameters": Array [],
       "ReturnType": Object {
         "ApiTypeKind": "basic",
         "Flags": 2,
@@ -173,7 +211,7 @@ Object {
         "Name": undefined,
         "Text": "string",
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "Parameter-0": Object {
       "ApiKind": "parameter",

--- a/tests/cases/__tests__/__snapshots__/ExportSpecifier1.test.ts.snap
+++ b/tests/cases/__tests__/__snapshots__/ExportSpecifier1.test.ts.snap
@@ -7,9 +7,14 @@ Object {
       "ApiKind": "source-file",
       "Kind": 265,
       "KindString": "SourceFile",
-      "Members": Object {
-        "Foo": "ExportSpecifier-0",
-      },
+      "Members": Array [
+        Array [
+          "Foo",
+          Array [
+            "ExportSpecifier-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
@@ -26,18 +31,38 @@ Object {
       "IsAbstract": true,
       "Kind": 229,
       "KindString": "ClassDeclaration",
-      "Members": Object {
-        "Bar": "PropertyDeclaration-1",
-        "GetFoo": "MethodDeclaration-1",
-        "Id": "PropertyDeclaration-0",
-        "SetFoo": "MethodDeclaration-0",
-      },
+      "Members": Array [
+        Array [
+          "SetFoo",
+          Array [
+            "MethodDeclaration-0",
+          ],
+        ],
+        Array [
+          "GetFoo",
+          Array [
+            "MethodDeclaration-1",
+          ],
+        ],
+        Array [
+          "Id",
+          Array [
+            "PropertyDeclaration-0",
+          ],
+        ],
+        Array [
+          "Bar",
+          Array [
+            "PropertyDeclaration-1",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "Foo",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "ExportSpecifier-0": Object {
       "ApiItems": Array [
@@ -65,9 +90,14 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "SetFoo",
-      "Parameters": Object {
-        "foo": "Parameter-0",
-      },
+      "Parameters": Array [
+        Array [
+          "foo",
+          Array [
+            "Parameter-0",
+          ],
+        ],
+      ],
       "ReturnType": Object {
         "ApiTypeKind": "basic",
         "Flags": 1024,
@@ -76,7 +106,7 @@ Object {
         "Name": undefined,
         "Text": "void",
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "MethodDeclaration-1": Object {
       "AccessModifier": "public",
@@ -91,7 +121,7 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "GetFoo",
-      "Parameters": Object {},
+      "Parameters": Array [],
       "ReturnType": Object {
         "ApiTypeKind": "basic",
         "Flags": 2,
@@ -100,7 +130,7 @@ Object {
         "Name": undefined,
         "Text": "string",
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "Parameter-0": Object {
       "ApiKind": "parameter",

--- a/tests/cases/__tests__/__snapshots__/ExportSpecifier2.test.ts.snap
+++ b/tests/cases/__tests__/__snapshots__/ExportSpecifier2.test.ts.snap
@@ -7,10 +7,20 @@ Object {
       "ApiKind": "source-file",
       "Kind": 265,
       "KindString": "SourceFile",
-      "Members": Object {
-        "Foo": "ExportSpecifier-0",
-        "Foo2": "ExportSpecifier-1",
-      },
+      "Members": Array [
+        Array [
+          "Foo",
+          Array [
+            "ExportSpecifier-0",
+          ],
+        ],
+        Array [
+          "Foo2",
+          Array [
+            "ExportSpecifier-1",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
@@ -51,30 +61,40 @@ Object {
       "Extends": Array [],
       "Kind": 230,
       "KindString": "InterfaceDeclaration",
-      "Members": Object {
-        "Bar": "PropertySignature-0",
-      },
+      "Members": Array [
+        Array [
+          "Bar",
+          Array [
+            "PropertySignature-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "Foo",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "InterfaceDeclaration-1": Object {
       "ApiKind": "interface",
       "Extends": Array [],
       "Kind": 230,
       "KindString": "InterfaceDeclaration",
-      "Members": Object {
-        "Bar2": "PropertySignature-1",
-      },
+      "Members": Array [
+        Array [
+          "Bar2",
+          Array [
+            "PropertySignature-1",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "Foo2",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "PropertySignature-0": Object {
       "ApiKind": "property",

--- a/tests/cases/__tests__/__snapshots__/ExportSpecifier3.test.ts.snap
+++ b/tests/cases/__tests__/__snapshots__/ExportSpecifier3.test.ts.snap
@@ -7,10 +7,20 @@ Object {
       "ApiKind": "source-file",
       "Kind": 265,
       "KindString": "SourceFile",
-      "Members": Object {
-        "Bar": "ExportSpecifier-0",
-        "FooClass": "ExportSpecifier-1",
-      },
+      "Members": Array [
+        Array [
+          "Bar",
+          Array [
+            "ExportSpecifier-0",
+          ],
+        ],
+        Array [
+          "FooClass",
+          Array [
+            "ExportSpecifier-1",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
@@ -42,16 +52,26 @@ Object {
       "IsAbstract": false,
       "Kind": 229,
       "KindString": "ClassDeclaration",
-      "Members": Object {
-        "Bar": "PropertyDeclaration-0",
-        "Bar2": "PropertyDeclaration-1",
-      },
+      "Members": Array [
+        Array [
+          "Bar",
+          Array [
+            "PropertyDeclaration-0",
+          ],
+        ],
+        Array [
+          "Bar2",
+          Array [
+            "PropertyDeclaration-1",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "FooClass",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "ExportSpecifier-0": Object {
       "ApiItems": Array [
@@ -84,30 +104,40 @@ Object {
       "Extends": Array [],
       "Kind": 230,
       "KindString": "InterfaceDeclaration",
-      "Members": Object {
-        "Bar": "PropertySignature-0",
-      },
+      "Members": Array [
+        Array [
+          "Bar",
+          Array [
+            "PropertySignature-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "Foo",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "InterfaceDeclaration-1": Object {
       "ApiKind": "interface",
       "Extends": Array [],
       "Kind": 230,
       "KindString": "InterfaceDeclaration",
-      "Members": Object {
-        "Bar2": "PropertySignature-1",
-      },
+      "Members": Array [
+        Array [
+          "Bar2",
+          Array [
+            "PropertySignature-1",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "Foo2",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "PropertyDeclaration-0": Object {
       "AccessModifier": "public",

--- a/tests/cases/__tests__/__snapshots__/FunctionDeclaration1.test.ts.snap
+++ b/tests/cases/__tests__/__snapshots__/FunctionDeclaration1.test.ts.snap
@@ -7,9 +7,14 @@ Object {
       "ApiKind": "source-file",
       "Kind": 265,
       "KindString": "SourceFile",
-      "Members": Object {
-        "Foo": "FunctionDeclaration-0",
-      },
+      "Members": Array [
+        Array [
+          "Foo",
+          Array [
+            "FunctionDeclaration-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
@@ -28,7 +33,7 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "Foo",
-      "Parameters": Object {},
+      "Parameters": Array [],
       "ReturnType": Object {
         "ApiTypeKind": "basic",
         "Flags": 2,
@@ -37,7 +42,7 @@ Object {
         "Name": undefined,
         "Text": "string",
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
   },
 }

--- a/tests/cases/__tests__/__snapshots__/FunctionDeclaration2.test.ts.snap
+++ b/tests/cases/__tests__/__snapshots__/FunctionDeclaration2.test.ts.snap
@@ -7,9 +7,14 @@ Object {
       "ApiKind": "source-file",
       "Kind": 265,
       "KindString": "SourceFile",
-      "Members": Object {
-        "Foo": "FunctionDeclaration-0",
-      },
+      "Members": Array [
+        Array [
+          "Foo",
+          Array [
+            "FunctionDeclaration-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
@@ -28,9 +33,14 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "Foo",
-      "Parameters": Object {
-        "value": "Parameter-0",
-      },
+      "Parameters": Array [
+        Array [
+          "value",
+          Array [
+            "Parameter-0",
+          ],
+        ],
+      ],
       "ReturnType": Object {
         "ApiTypeKind": "basic",
         "Flags": 1024,
@@ -39,9 +49,14 @@ Object {
         "Name": undefined,
         "Text": "void",
       },
-      "TypeParameters": Object {
-        "TValue": "TypeParameter-0",
-      },
+      "TypeParameters": Array [
+        Array [
+          "TValue",
+          Array [
+            "TypeParameter-0",
+          ],
+        ],
+      ],
     },
     "Parameter-0": Object {
       "ApiKind": "parameter",

--- a/tests/cases/__tests__/__snapshots__/InterfaceClassMerging.test.ts.snap
+++ b/tests/cases/__tests__/__snapshots__/InterfaceClassMerging.test.ts.snap
@@ -7,16 +7,39 @@ Object {
       "ApiKind": "source-file",
       "Kind": 265,
       "KindString": "SourceFile",
-      "Members": Object {
-        "Bar": "ClassDeclaration-1",
-        "Foo": Array [
-          "InterfaceDeclaration-0",
-          "ClassDeclaration-0",
+      "Members": Array [
+        Array [
+          "Foo",
+          Array [
+            "InterfaceDeclaration-0",
+            "ClassDeclaration-0",
+          ],
         ],
-        "bar": "VariableDeclaration-0",
-        "foo": "VariableDeclaration-1",
-        "iFoo": "VariableDeclaration-2",
-      },
+        Array [
+          "Bar",
+          Array [
+            "ClassDeclaration-1",
+          ],
+        ],
+        Array [
+          "bar",
+          Array [
+            "VariableDeclaration-0",
+          ],
+        ],
+        Array [
+          "foo",
+          Array [
+            "VariableDeclaration-1",
+          ],
+        ],
+        Array [
+          "iFoo",
+          Array [
+            "VariableDeclaration-2",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
@@ -33,16 +56,26 @@ Object {
       "IsAbstract": false,
       "Kind": 229,
       "KindString": "ClassDeclaration",
-      "Members": Object {
-        "additionalMethod": "MethodDeclaration-0",
-        "additionalProperty": "PropertyDeclaration-0",
-      },
+      "Members": Array [
+        Array [
+          "additionalProperty",
+          Array [
+            "PropertyDeclaration-0",
+          ],
+        ],
+        Array [
+          "additionalMethod",
+          Array [
+            "MethodDeclaration-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "Foo",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "ClassDeclaration-1": Object {
       "ApiKind": "class",
@@ -57,33 +90,58 @@ Object {
       "IsAbstract": false,
       "Kind": 229,
       "KindString": "ClassDeclaration",
-      "Members": Object {
-        "method": "MethodDeclaration-1",
-      },
+      "Members": Array [
+        Array [
+          "method",
+          Array [
+            "MethodDeclaration-1",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "Bar",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "InterfaceDeclaration-0": Object {
       "ApiKind": "interface",
       "Extends": Array [],
       "Kind": 230,
       "KindString": "InterfaceDeclaration",
-      "Members": Object {
-        "method": "MethodSignature-0",
-        "optionalMethod": "MethodSignature-1",
-        "optionalProperty": "PropertySignature-1",
-        "property": "PropertySignature-0",
-      },
+      "Members": Array [
+        Array [
+          "method",
+          Array [
+            "MethodSignature-0",
+          ],
+        ],
+        Array [
+          "optionalMethod",
+          Array [
+            "MethodSignature-1",
+          ],
+        ],
+        Array [
+          "property",
+          Array [
+            "PropertySignature-0",
+          ],
+        ],
+        Array [
+          "optionalProperty",
+          Array [
+            "PropertySignature-1",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "Foo",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "MethodDeclaration-0": Object {
       "AccessModifier": "public",
@@ -98,9 +156,14 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "additionalMethod",
-      "Parameters": Object {
-        "a": "Parameter-2",
-      },
+      "Parameters": Array [
+        Array [
+          "a",
+          Array [
+            "Parameter-2",
+          ],
+        ],
+      ],
       "ReturnType": Object {
         "ApiTypeKind": "basic",
         "Flags": 2,
@@ -109,7 +172,7 @@ Object {
         "Name": undefined,
         "Text": "string",
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "MethodDeclaration-1": Object {
       "AccessModifier": "public",
@@ -124,9 +187,14 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "method",
-      "Parameters": Object {
-        "a": "Parameter-3",
-      },
+      "Parameters": Array [
+        Array [
+          "a",
+          Array [
+            "Parameter-3",
+          ],
+        ],
+      ],
       "ReturnType": Object {
         "ApiTypeKind": "basic",
         "Flags": 2,
@@ -135,7 +203,7 @@ Object {
         "Name": undefined,
         "Text": "string",
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "MethodSignature-0": Object {
       "ApiKind": "method",
@@ -147,9 +215,14 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "method",
-      "Parameters": Object {
-        "a": "Parameter-0",
-      },
+      "Parameters": Array [
+        Array [
+          "a",
+          Array [
+            "Parameter-0",
+          ],
+        ],
+      ],
       "ReturnType": Object {
         "ApiTypeKind": "basic",
         "Flags": 2,
@@ -158,7 +231,7 @@ Object {
         "Name": undefined,
         "Text": "string",
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "MethodSignature-1": Object {
       "ApiKind": "method",
@@ -170,9 +243,14 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "optionalMethod",
-      "Parameters": Object {
-        "a": "Parameter-1",
-      },
+      "Parameters": Array [
+        Array [
+          "a",
+          Array [
+            "Parameter-1",
+          ],
+        ],
+      ],
       "ReturnType": Object {
         "ApiTypeKind": "basic",
         "Flags": 2,
@@ -181,7 +259,7 @@ Object {
         "Name": undefined,
         "Text": "string",
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "Parameter-0": Object {
       "ApiKind": "parameter",

--- a/tests/cases/__tests__/__snapshots__/InterfaceDeclaration1.test.ts.snap
+++ b/tests/cases/__tests__/__snapshots__/InterfaceDeclaration1.test.ts.snap
@@ -7,9 +7,14 @@ Object {
       "ApiKind": "source-file",
       "Kind": 265,
       "KindString": "SourceFile",
-      "Members": Object {
-        "Foo": "InterfaceDeclaration-0",
-      },
+      "Members": Array [
+        Array [
+          "Foo",
+          Array [
+            "InterfaceDeclaration-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
@@ -24,13 +29,13 @@ Object {
       "Extends": Array [],
       "Kind": 230,
       "KindString": "InterfaceDeclaration",
-      "Members": Object {},
+      "Members": Array [],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "Foo",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
   },
 }

--- a/tests/cases/__tests__/__snapshots__/InterfaceDeclaration2.test.ts.snap
+++ b/tests/cases/__tests__/__snapshots__/InterfaceDeclaration2.test.ts.snap
@@ -7,9 +7,14 @@ Object {
       "ApiKind": "source-file",
       "Kind": 265,
       "KindString": "SourceFile",
-      "Members": Object {
-        "Foo": "InterfaceDeclaration-0",
-      },
+      "Members": Array [
+        Array [
+          "Foo",
+          Array [
+            "InterfaceDeclaration-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
@@ -24,15 +29,20 @@ Object {
       "Extends": Array [],
       "Kind": 230,
       "KindString": "InterfaceDeclaration",
-      "Members": Object {
-        "Bar": "PropertySignature-0",
-      },
+      "Members": Array [
+        Array [
+          "Bar",
+          Array [
+            "PropertySignature-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "Foo",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "PropertySignature-0": Object {
       "ApiKind": "property",

--- a/tests/cases/__tests__/__snapshots__/InterfaceDeclaration3.test.ts.snap
+++ b/tests/cases/__tests__/__snapshots__/InterfaceDeclaration3.test.ts.snap
@@ -7,10 +7,20 @@ Object {
       "ApiKind": "source-file",
       "Kind": 265,
       "KindString": "SourceFile",
-      "Members": Object {
-        "Generic": "InterfaceDeclaration-0",
-        "y": "VariableDeclaration-0",
-      },
+      "Members": Array [
+        Array [
+          "Generic",
+          Array [
+            "InterfaceDeclaration-0",
+          ],
+        ],
+        Array [
+          "y",
+          Array [
+            "VariableDeclaration-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
@@ -25,17 +35,27 @@ Object {
       "Extends": Array [],
       "Kind": 230,
       "KindString": "InterfaceDeclaration",
-      "Members": Object {
-        "x": "PropertySignature-0",
-      },
+      "Members": Array [
+        Array [
+          "x",
+          Array [
+            "PropertySignature-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "Generic",
-      "TypeParameters": Object {
-        "T": "TypeParameter-0",
-      },
+      "TypeParameters": Array [
+        Array [
+          "T",
+          Array [
+            "TypeParameter-0",
+          ],
+        ],
+      ],
     },
     "PropertySignature-0": Object {
       "ApiKind": "property",

--- a/tests/cases/__tests__/__snapshots__/InterfaceDeclaration4.test.ts.snap
+++ b/tests/cases/__tests__/__snapshots__/InterfaceDeclaration4.test.ts.snap
@@ -7,17 +7,62 @@ Object {
       "ApiKind": "source-file",
       "Kind": 265,
       "KindString": "SourceFile",
-      "Members": Object {
-        "a": "InterfaceDeclaration-3",
-        "a0": "InterfaceDeclaration-0",
-        "a1": "InterfaceDeclaration-1",
-        "a2": "InterfaceDeclaration-2",
-        "b": "InterfaceDeclaration-4",
-        "c": "InterfaceDeclaration-5",
-        "c1": "ClassDeclaration-0",
-        "d": "InterfaceDeclaration-6",
-        "instance2": "VariableDeclaration-0",
-      },
+      "Members": Array [
+        Array [
+          "a0",
+          Array [
+            "InterfaceDeclaration-0",
+          ],
+        ],
+        Array [
+          "a1",
+          Array [
+            "InterfaceDeclaration-1",
+          ],
+        ],
+        Array [
+          "a2",
+          Array [
+            "InterfaceDeclaration-2",
+          ],
+        ],
+        Array [
+          "a",
+          Array [
+            "InterfaceDeclaration-3",
+          ],
+        ],
+        Array [
+          "b",
+          Array [
+            "InterfaceDeclaration-4",
+          ],
+        ],
+        Array [
+          "c",
+          Array [
+            "InterfaceDeclaration-5",
+          ],
+        ],
+        Array [
+          "d",
+          Array [
+            "InterfaceDeclaration-6",
+          ],
+        ],
+        Array [
+          "c1",
+          Array [
+            "ClassDeclaration-0",
+          ],
+        ],
+        Array [
+          "instance2",
+          Array [
+            "VariableDeclaration-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
@@ -36,7 +81,7 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "__call",
-      "Parameters": Object {},
+      "Parameters": Array [],
       "ReturnType": Object {
         "ApiTypeKind": "basic",
         "Flags": 2,
@@ -45,7 +90,7 @@ Object {
         "Name": undefined,
         "Text": "string",
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "CallSignature-1": Object {
       "ApiKind": "call",
@@ -56,11 +101,26 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "__call",
-      "Parameters": Object {
-        "a": "Parameter-0",
-        "b": "Parameter-1",
-        "c": "Parameter-2",
-      },
+      "Parameters": Array [
+        Array [
+          "a",
+          Array [
+            "Parameter-0",
+          ],
+        ],
+        Array [
+          "b",
+          Array [
+            "Parameter-1",
+          ],
+        ],
+        Array [
+          "c",
+          Array [
+            "Parameter-2",
+          ],
+        ],
+      ],
       "ReturnType": Object {
         "ApiTypeKind": "basic",
         "Flags": 4,
@@ -69,7 +129,7 @@ Object {
         "Name": undefined,
         "Text": "number",
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "ClassDeclaration-0": Object {
       "ApiKind": "class",
@@ -86,13 +146,13 @@ Object {
       "IsAbstract": false,
       "Kind": 229,
       "KindString": "ClassDeclaration",
-      "Members": Object {},
+      "Members": Array [],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "c1",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "ConstructSignature-0": Object {
       "ApiKind": "construct",
@@ -103,7 +163,7 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "__new",
-      "Parameters": Object {},
+      "Parameters": Array [],
     },
     "ConstructSignature-1": Object {
       "ApiKind": "construct",
@@ -114,9 +174,14 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "__new",
-      "Parameters": Object {
-        "s": "Parameter-3",
-      },
+      "Parameters": Array [
+        Array [
+          "s",
+          Array [
+            "Parameter-3",
+          ],
+        ],
+      ],
     },
     "FunctionType-0": Object {
       "ApiKind": "function",
@@ -127,7 +192,7 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "__type",
-      "Parameters": Object {},
+      "Parameters": Array [],
       "ReturnType": Object {
         "ApiTypeKind": "basic",
         "Flags": 2,
@@ -136,7 +201,7 @@ Object {
         "Name": undefined,
         "Text": "string",
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "IndexSignature-0": Object {
       "ApiKind": "index",
@@ -218,78 +283,142 @@ Object {
       "Extends": Array [],
       "Kind": 230,
       "KindString": "InterfaceDeclaration",
-      "Members": Object {
-        "__call": Array [
-          "CallSignature-0",
-          "CallSignature-1",
+      "Members": Array [
+        Array [
+          "__call",
+          Array [
+            "CallSignature-0",
+            "CallSignature-1",
+          ],
         ],
-        "__index": Array [
-          "IndexSignature-0",
-          "IndexSignature-1",
+        Array [
+          "__new",
+          Array [
+            "ConstructSignature-0",
+            "ConstructSignature-1",
+          ],
         ],
-        "__new": Array [
-          "ConstructSignature-0",
-          "ConstructSignature-1",
+        Array [
+          "__index",
+          Array [
+            "IndexSignature-0",
+            "IndexSignature-1",
+          ],
         ],
-        "f1": "MethodSignature-1",
-        "f2": "MethodSignature-2",
-        "f3": "MethodSignature-3",
-        "f4": "MethodSignature-4",
-        "p1": "PropertySignature-0",
-        "p2": "PropertySignature-2",
-        "p3": "PropertySignature-1",
-        "p4": "PropertySignature-3",
-        "p5": "MethodSignature-0",
-      },
+        Array [
+          "p1",
+          Array [
+            "PropertySignature-0",
+          ],
+        ],
+        Array [
+          "p3",
+          Array [
+            "PropertySignature-1",
+          ],
+        ],
+        Array [
+          "p2",
+          Array [
+            "PropertySignature-2",
+          ],
+        ],
+        Array [
+          "p4",
+          Array [
+            "PropertySignature-3",
+          ],
+        ],
+        Array [
+          "p5",
+          Array [
+            "MethodSignature-0",
+          ],
+        ],
+        Array [
+          "f1",
+          Array [
+            "MethodSignature-1",
+          ],
+        ],
+        Array [
+          "f2",
+          Array [
+            "MethodSignature-2",
+          ],
+        ],
+        Array [
+          "f3",
+          Array [
+            "MethodSignature-3",
+          ],
+        ],
+        Array [
+          "f4",
+          Array [
+            "MethodSignature-4",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "a0",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "InterfaceDeclaration-1": Object {
       "ApiKind": "interface",
       "Extends": Array [],
       "Kind": 230,
       "KindString": "InterfaceDeclaration",
-      "Members": Object {
-        "__index": "IndexSignature-2",
-      },
+      "Members": Array [
+        Array [
+          "__index",
+          Array [
+            "IndexSignature-2",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "a1",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "InterfaceDeclaration-2": Object {
       "ApiKind": "interface",
       "Extends": Array [],
       "Kind": 230,
       "KindString": "InterfaceDeclaration",
-      "Members": Object {
-        "__index": "IndexSignature-3",
-      },
+      "Members": Array [
+        Array [
+          "__index",
+          Array [
+            "IndexSignature-3",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "a2",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "InterfaceDeclaration-3": Object {
       "ApiKind": "interface",
       "Extends": Array [],
       "Kind": 230,
       "KindString": "InterfaceDeclaration",
-      "Members": Object {},
+      "Members": Array [],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "a",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "InterfaceDeclaration-4": Object {
       "ApiKind": "interface",
@@ -304,13 +433,13 @@ Object {
       ],
       "Kind": 230,
       "KindString": "InterfaceDeclaration",
-      "Members": Object {},
+      "Members": Array [],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "b",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "InterfaceDeclaration-5": Object {
       "ApiKind": "interface",
@@ -332,13 +461,13 @@ Object {
       ],
       "Kind": 230,
       "KindString": "InterfaceDeclaration",
-      "Members": Object {},
+      "Members": Array [],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "c",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "InterfaceDeclaration-6": Object {
       "ApiKind": "interface",
@@ -353,13 +482,13 @@ Object {
       ],
       "Kind": 230,
       "KindString": "InterfaceDeclaration",
-      "Members": Object {},
+      "Members": Array [],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "d",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "MethodSignature-0": Object {
       "ApiKind": "method",
@@ -371,9 +500,14 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "p5",
-      "Parameters": Object {
-        "s": "Parameter-6",
-      },
+      "Parameters": Array [
+        Array [
+          "s",
+          Array [
+            "Parameter-6",
+          ],
+        ],
+      ],
       "ReturnType": Object {
         "ApiTypeKind": "basic",
         "Flags": 2,
@@ -382,7 +516,7 @@ Object {
         "Name": undefined,
         "Text": "string",
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "MethodSignature-1": Object {
       "ApiKind": "method",
@@ -394,7 +528,7 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "f1",
-      "Parameters": Object {},
+      "Parameters": Array [],
       "ReturnType": Object {
         "ApiTypeKind": "basic",
         "Flags": 1,
@@ -403,7 +537,7 @@ Object {
         "Name": undefined,
         "Text": "any",
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "MethodSignature-2": Object {
       "ApiKind": "method",
@@ -415,7 +549,7 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "f2",
-      "Parameters": Object {},
+      "Parameters": Array [],
       "ReturnType": Object {
         "ApiTypeKind": "basic",
         "Flags": 1,
@@ -424,7 +558,7 @@ Object {
         "Name": undefined,
         "Text": "any",
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "MethodSignature-3": Object {
       "ApiKind": "method",
@@ -436,9 +570,14 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "f3",
-      "Parameters": Object {
-        "a": "Parameter-7",
-      },
+      "Parameters": Array [
+        Array [
+          "a",
+          Array [
+            "Parameter-7",
+          ],
+        ],
+      ],
       "ReturnType": Object {
         "ApiTypeKind": "basic",
         "Flags": 4,
@@ -447,7 +586,7 @@ Object {
         "Name": undefined,
         "Text": "number",
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "MethodSignature-4": Object {
       "ApiKind": "method",
@@ -459,9 +598,14 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "f4",
-      "Parameters": Object {
-        "s": "Parameter-8",
-      },
+      "Parameters": Array [
+        Array [
+          "s",
+          Array [
+            "Parameter-8",
+          ],
+        ],
+      ],
       "ReturnType": Object {
         "ApiTypeKind": "basic",
         "Flags": 2,
@@ -470,7 +614,7 @@ Object {
         "Name": undefined,
         "Text": "string",
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "Parameter-0": Object {
       "ApiKind": "parameter",

--- a/tests/cases/__tests__/__snapshots__/InterfaceDeclaration5.test.ts.snap
+++ b/tests/cases/__tests__/__snapshots__/InterfaceDeclaration5.test.ts.snap
@@ -7,9 +7,14 @@ Object {
       "ApiKind": "source-file",
       "Kind": 265,
       "KindString": "SourceFile",
-      "Members": Object {
-        "GenericIdentityFn": "InterfaceDeclaration-0",
-      },
+      "Members": Array [
+        Array [
+          "GenericIdentityFn",
+          Array [
+            "InterfaceDeclaration-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
@@ -28,9 +33,14 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "__call",
-      "Parameters": Object {
-        "value": "Parameter-0",
-      },
+      "Parameters": Array [
+        Array [
+          "value",
+          Array [
+            "Parameter-0",
+          ],
+        ],
+      ],
       "ReturnType": Object {
         "ApiTypeKind": "reference",
         "Generics": undefined,
@@ -38,24 +48,34 @@ Object {
         "ReferenceId": "TypeParameter-0",
         "Text": "TValue",
       },
-      "TypeParameters": Object {
-        "TValue": "TypeParameter-0",
-      },
+      "TypeParameters": Array [
+        Array [
+          "TValue",
+          Array [
+            "TypeParameter-0",
+          ],
+        ],
+      ],
     },
     "InterfaceDeclaration-0": Object {
       "ApiKind": "interface",
       "Extends": Array [],
       "Kind": 230,
       "KindString": "InterfaceDeclaration",
-      "Members": Object {
-        "__call": "CallSignature-0",
-      },
+      "Members": Array [
+        Array [
+          "__call",
+          Array [
+            "CallSignature-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "GenericIdentityFn",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "Parameter-0": Object {
       "ApiKind": "parameter",

--- a/tests/cases/__tests__/__snapshots__/InterfaceDeclaration6.test.ts.snap
+++ b/tests/cases/__tests__/__snapshots__/InterfaceDeclaration6.test.ts.snap
@@ -7,9 +7,14 @@ Object {
       "ApiKind": "source-file",
       "Kind": 265,
       "KindString": "SourceFile",
-      "Members": Object {
-        "Foo": "InterfaceDeclaration-0",
-      },
+      "Members": Array [
+        Array [
+          "Foo",
+          Array [
+            "InterfaceDeclaration-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
@@ -24,17 +29,27 @@ Object {
       "Extends": Array [],
       "Kind": 230,
       "KindString": "InterfaceDeclaration",
-      "Members": Object {
-        "Bar": "MethodSignature-0",
-      },
+      "Members": Array [
+        Array [
+          "Bar",
+          Array [
+            "MethodSignature-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "Foo",
-      "TypeParameters": Object {
-        "TValue": "TypeParameter-1",
-      },
+      "TypeParameters": Array [
+        Array [
+          "TValue",
+          Array [
+            "TypeParameter-1",
+          ],
+        ],
+      ],
     },
     "MethodSignature-0": Object {
       "ApiKind": "method",
@@ -46,9 +61,14 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "Bar",
-      "Parameters": Object {
-        "args": "Parameter-0",
-      },
+      "Parameters": Array [
+        Array [
+          "args",
+          Array [
+            "Parameter-0",
+          ],
+        ],
+      ],
       "ReturnType": Object {
         "ApiTypeKind": "basic",
         "Flags": 1024,
@@ -57,9 +77,14 @@ Object {
         "Name": undefined,
         "Text": "void",
       },
-      "TypeParameters": Object {
-        "TValue": "TypeParameter-0",
-      },
+      "TypeParameters": Array [
+        Array [
+          "TValue",
+          Array [
+            "TypeParameter-0",
+          ],
+        ],
+      ],
     },
     "Parameter-0": Object {
       "ApiKind": "parameter",

--- a/tests/cases/__tests__/__snapshots__/InterfaceSubtyping.test.ts.snap
+++ b/tests/cases/__tests__/__snapshots__/InterfaceSubtyping.test.ts.snap
@@ -7,10 +7,20 @@ Object {
       "ApiKind": "source-file",
       "Kind": 265,
       "KindString": "SourceFile",
-      "Members": Object {
-        "Camera": "ClassDeclaration-0",
-        "Face": "InterfaceDeclaration-0",
-      },
+      "Members": Array [
+        Array [
+          "Face",
+          Array [
+            "InterfaceDeclaration-0",
+          ],
+        ],
+        Array [
+          "Camera",
+          Array [
+            "ClassDeclaration-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
@@ -35,16 +45,26 @@ Object {
       "IsAbstract": false,
       "Kind": 229,
       "KindString": "ClassDeclaration",
-      "Members": Object {
-        "__constructor": "Constructor-0",
-        "foo": "MethodDeclaration-0",
-      },
+      "Members": Array [
+        Array [
+          "__constructor",
+          Array [
+            "Constructor-0",
+          ],
+        ],
+        Array [
+          "foo",
+          Array [
+            "MethodDeclaration-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "Camera",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "Constructor-0": Object {
       "AccessModifier": "public",
@@ -56,24 +76,34 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "__constructor",
-      "Parameters": Object {
-        "str": "Parameter-0",
-      },
+      "Parameters": Array [
+        Array [
+          "str",
+          Array [
+            "Parameter-0",
+          ],
+        ],
+      ],
     },
     "InterfaceDeclaration-0": Object {
       "ApiKind": "interface",
       "Extends": Array [],
       "Kind": 230,
       "KindString": "InterfaceDeclaration",
-      "Members": Object {
-        "foo": "MethodSignature-0",
-      },
+      "Members": Array [
+        Array [
+          "foo",
+          Array [
+            "MethodSignature-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "Face",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "MethodDeclaration-0": Object {
       "AccessModifier": "public",
@@ -88,7 +118,7 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "foo",
-      "Parameters": Object {},
+      "Parameters": Array [],
       "ReturnType": Object {
         "ApiTypeKind": "basic",
         "Flags": 2,
@@ -97,7 +127,7 @@ Object {
         "Name": undefined,
         "Text": "string",
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "MethodSignature-0": Object {
       "ApiKind": "method",
@@ -109,7 +139,7 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "foo",
-      "Parameters": Object {},
+      "Parameters": Array [],
       "ReturnType": Object {
         "ApiTypeKind": "basic",
         "Flags": 1024,
@@ -118,7 +148,7 @@ Object {
         "Name": undefined,
         "Text": "void",
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "Parameter-0": Object {
       "ApiKind": "parameter",

--- a/tests/cases/__tests__/__snapshots__/MultipleDeclaration.test.ts.snap
+++ b/tests/cases/__tests__/__snapshots__/MultipleDeclaration.test.ts.snap
@@ -7,17 +7,28 @@ Object {
       "ApiKind": "source-file",
       "Kind": 265,
       "KindString": "SourceFile",
-      "Members": Object {
-        "Bar": Array [
-          "ClassDeclaration-1",
-          "InterfaceDeclaration-1",
+      "Members": Array [
+        Array [
+          "M",
+          Array [
+            "ModuleDeclaration-0",
+          ],
         ],
-        "Foo": Array [
-          "InterfaceDeclaration-0",
-          "ClassDeclaration-0",
+        Array [
+          "Foo",
+          Array [
+            "InterfaceDeclaration-0",
+            "ClassDeclaration-0",
+          ],
         ],
-        "M": "ModuleDeclaration-0",
-      },
+        Array [
+          "Bar",
+          Array [
+            "ClassDeclaration-1",
+            "InterfaceDeclaration-1",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
@@ -34,17 +45,27 @@ Object {
       "IsAbstract": false,
       "Kind": 229,
       "KindString": "ClassDeclaration",
-      "Members": Object {
-        "b": "PropertyDeclaration-0",
-      },
+      "Members": Array [
+        Array [
+          "b",
+          Array [
+            "PropertyDeclaration-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "Foo",
-      "TypeParameters": Object {
-        "T": "TypeParameter-1",
-      },
+      "TypeParameters": Array [
+        Array [
+          "T",
+          Array [
+            "TypeParameter-1",
+          ],
+        ],
+      ],
     },
     "ClassDeclaration-1": Object {
       "ApiKind": "class",
@@ -53,57 +74,87 @@ Object {
       "IsAbstract": false,
       "Kind": 229,
       "KindString": "ClassDeclaration",
-      "Members": Object {
-        "b": "PropertyDeclaration-1",
-      },
+      "Members": Array [
+        Array [
+          "b",
+          Array [
+            "PropertyDeclaration-1",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "Bar",
-      "TypeParameters": Object {
-        "T": "TypeParameter-2",
-      },
+      "TypeParameters": Array [
+        Array [
+          "T",
+          Array [
+            "TypeParameter-2",
+          ],
+        ],
+      ],
     },
     "InterfaceDeclaration-0": Object {
       "ApiKind": "interface",
       "Extends": Array [],
       "Kind": 230,
       "KindString": "InterfaceDeclaration",
-      "Members": Object {
-        "a": "PropertySignature-0",
-      },
+      "Members": Array [
+        Array [
+          "a",
+          Array [
+            "PropertySignature-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "Foo",
-      "TypeParameters": Object {
-        "T": "TypeParameter-0",
-      },
+      "TypeParameters": Array [
+        Array [
+          "T",
+          Array [
+            "TypeParameter-0",
+          ],
+        ],
+      ],
     },
     "InterfaceDeclaration-1": Object {
       "ApiKind": "interface",
       "Extends": Array [],
       "Kind": 230,
       "KindString": "InterfaceDeclaration",
-      "Members": Object {
-        "a": "PropertySignature-1",
-      },
+      "Members": Array [
+        Array [
+          "a",
+          Array [
+            "PropertySignature-1",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "Bar",
-      "TypeParameters": Object {
-        "T": "TypeParameter-3",
-      },
+      "TypeParameters": Array [
+        Array [
+          "T",
+          Array [
+            "TypeParameter-3",
+          ],
+        ],
+      ],
     },
     "ModuleDeclaration-0": Object {
       "ApiKind": "namespace",
       "Kind": 233,
       "KindString": "ModuleDeclaration",
-      "Members": Object {},
+      "Members": Array [],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],

--- a/tests/cases/__tests__/__snapshots__/ParameterDeclaration1.test.ts.snap
+++ b/tests/cases/__tests__/__snapshots__/ParameterDeclaration1.test.ts.snap
@@ -7,9 +7,14 @@ Object {
       "ApiKind": "source-file",
       "Kind": 265,
       "KindString": "SourceFile",
-      "Members": Object {
-        "FooFunction": "FunctionDeclaration-0",
-      },
+      "Members": Array [
+        Array [
+          "FooFunction",
+          Array [
+            "FunctionDeclaration-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
@@ -28,9 +33,14 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "FooFunction",
-      "Parameters": Object {
-        "bar": "Parameter-0",
-      },
+      "Parameters": Array [
+        Array [
+          "bar",
+          Array [
+            "Parameter-0",
+          ],
+        ],
+      ],
       "ReturnType": Object {
         "ApiTypeKind": "basic",
         "Flags": 1024,
@@ -39,7 +49,7 @@ Object {
         "Name": undefined,
         "Text": "void",
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "Parameter-0": Object {
       "ApiKind": "parameter",

--- a/tests/cases/__tests__/__snapshots__/ParameterDeclaration2.test.ts.snap
+++ b/tests/cases/__tests__/__snapshots__/ParameterDeclaration2.test.ts.snap
@@ -7,9 +7,14 @@ Object {
       "ApiKind": "source-file",
       "Kind": 265,
       "KindString": "SourceFile",
-      "Members": Object {
-        "FooFunction": "FunctionDeclaration-0",
-      },
+      "Members": Array [
+        Array [
+          "FooFunction",
+          Array [
+            "FunctionDeclaration-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
@@ -28,9 +33,14 @@ Object {
         "JSDocTags": Array [],
       },
       "Name": "FooFunction",
-      "Parameters": Object {
-        "bar": "Parameter-0",
-      },
+      "Parameters": Array [
+        Array [
+          "bar",
+          Array [
+            "Parameter-0",
+          ],
+        ],
+      ],
       "ReturnType": Object {
         "ApiTypeKind": "basic",
         "Flags": 1024,
@@ -39,20 +49,20 @@ Object {
         "Name": undefined,
         "Text": "void",
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "InterfaceDeclaration-0": Object {
       "ApiKind": "interface",
       "Extends": Array [],
       "Kind": 230,
       "KindString": "InterfaceDeclaration",
-      "Members": Object {},
+      "Members": Array [],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "Array",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "Parameter-0": Object {
       "ApiKind": "parameter",

--- a/tests/cases/__tests__/__snapshots__/TypeAliasDeclaration1.test.ts.snap
+++ b/tests/cases/__tests__/__snapshots__/TypeAliasDeclaration1.test.ts.snap
@@ -7,10 +7,20 @@ Object {
       "ApiKind": "source-file",
       "Kind": 265,
       "KindString": "SourceFile",
-      "Members": Object {
-        "AnotherType": "TypeAliasDeclaration-1",
-        "MyType": "TypeAliasDeclaration-0",
-      },
+      "Members": Array [
+        Array [
+          "MyType",
+          Array [
+            "TypeAliasDeclaration-0",
+          ],
+        ],
+        Array [
+          "AnotherType",
+          Array [
+            "TypeAliasDeclaration-1",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
@@ -55,7 +65,7 @@ Object {
         "ReferenceId": "TypeLiteral-0",
         "Text": "MyType",
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "TypeAliasDeclaration-1": Object {
       "ApiKind": "type",
@@ -73,15 +83,20 @@ Object {
         "ReferenceId": "TypeLiteral-0",
         "Text": "MyType",
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "TypeLiteral-0": Object {
       "ApiKind": "type-literal",
       "Kind": 163,
       "KindString": "TypeLiteral",
-      "Members": Object {
-        "BarName": "PropertySignature-0",
-      },
+      "Members": Array [
+        Array [
+          "BarName",
+          Array [
+            "PropertySignature-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],

--- a/tests/cases/__tests__/__snapshots__/TypeAliasDeclaration2.test.ts.snap
+++ b/tests/cases/__tests__/__snapshots__/TypeAliasDeclaration2.test.ts.snap
@@ -7,11 +7,26 @@ Object {
       "ApiKind": "source-file",
       "Kind": 265,
       "KindString": "SourceFile",
-      "Members": Object {
-        "OneCommonField1": "TypeAliasDeclaration-0",
-        "OneCommonField2": "TypeAliasDeclaration-1",
-        "OneCommonFieldTypeIntersection": "TypeAliasDeclaration-2",
-      },
+      "Members": Array [
+        Array [
+          "OneCommonField1",
+          Array [
+            "TypeAliasDeclaration-0",
+          ],
+        ],
+        Array [
+          "OneCommonField2",
+          Array [
+            "TypeAliasDeclaration-1",
+          ],
+        ],
+        Array [
+          "OneCommonFieldTypeIntersection",
+          Array [
+            "TypeAliasDeclaration-2",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
@@ -113,7 +128,7 @@ Object {
         "ReferenceId": "TypeLiteral-0",
         "Text": "OneCommonField1",
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "TypeAliasDeclaration-1": Object {
       "ApiKind": "type",
@@ -131,7 +146,7 @@ Object {
         "ReferenceId": "TypeLiteral-1",
         "Text": "OneCommonField2",
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "TypeAliasDeclaration-2": Object {
       "ApiKind": "type",
@@ -165,16 +180,26 @@ Object {
           },
         ],
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "TypeLiteral-0": Object {
       "ApiKind": "type-literal",
       "Kind": 163,
       "KindString": "TypeLiteral",
-      "Members": Object {
-        "BarName": "PropertySignature-0",
-        "FooName": "PropertySignature-1",
-      },
+      "Members": Array [
+        Array [
+          "BarName",
+          Array [
+            "PropertySignature-0",
+          ],
+        ],
+        Array [
+          "FooName",
+          Array [
+            "PropertySignature-1",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
@@ -185,10 +210,20 @@ Object {
       "ApiKind": "type-literal",
       "Kind": 163,
       "KindString": "TypeLiteral",
-      "Members": Object {
-        "BarName": "PropertySignature-2",
-        "BazName": "PropertySignature-3",
-      },
+      "Members": Array [
+        Array [
+          "BarName",
+          Array [
+            "PropertySignature-2",
+          ],
+        ],
+        Array [
+          "BazName",
+          Array [
+            "PropertySignature-3",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],

--- a/tests/cases/__tests__/__snapshots__/TypeAliasDeclaration3.test.ts.snap
+++ b/tests/cases/__tests__/__snapshots__/TypeAliasDeclaration3.test.ts.snap
@@ -7,15 +7,50 @@ Object {
       "ApiKind": "source-file",
       "Kind": 265,
       "KindString": "SourceFile",
-      "Members": Object {
-        "AnotherType": "TypeAliasDeclaration-2",
-        "NoCommonFields1": "TypeAliasDeclaration-0",
-        "NoCommonFields2": "TypeAliasDeclaration-1",
-        "OneCommonField1": "TypeAliasDeclaration-3",
-        "OneCommonField2": "TypeAliasDeclaration-4",
-        "OneCommonFieldTypeIntersection": "TypeAliasDeclaration-5",
-        "OneCommonFieldTypeIntersectionWithDifferentTypes": "TypeAliasDeclaration-6",
-      },
+      "Members": Array [
+        Array [
+          "NoCommonFields1",
+          Array [
+            "TypeAliasDeclaration-0",
+          ],
+        ],
+        Array [
+          "NoCommonFields2",
+          Array [
+            "TypeAliasDeclaration-1",
+          ],
+        ],
+        Array [
+          "AnotherType",
+          Array [
+            "TypeAliasDeclaration-2",
+          ],
+        ],
+        Array [
+          "OneCommonField1",
+          Array [
+            "TypeAliasDeclaration-3",
+          ],
+        ],
+        Array [
+          "OneCommonField2",
+          Array [
+            "TypeAliasDeclaration-4",
+          ],
+        ],
+        Array [
+          "OneCommonFieldTypeIntersection",
+          Array [
+            "TypeAliasDeclaration-5",
+          ],
+        ],
+        Array [
+          "OneCommonFieldTypeIntersectionWithDifferentTypes",
+          Array [
+            "TypeAliasDeclaration-6",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
@@ -178,9 +213,14 @@ Object {
         "ReferenceId": "TypeLiteral-0",
         "Text": "NoCommonFields1<TType>",
       },
-      "TypeParameters": Object {
-        "TType": "TypeParameter-0",
-      },
+      "TypeParameters": Array [
+        Array [
+          "TType",
+          Array [
+            "TypeParameter-0",
+          ],
+        ],
+      ],
     },
     "TypeAliasDeclaration-1": Object {
       "ApiKind": "type",
@@ -206,9 +246,14 @@ Object {
         "ReferenceId": "TypeLiteral-1",
         "Text": "NoCommonFields2<TType>",
       },
-      "TypeParameters": Object {
-        "TType": "TypeParameter-1",
-      },
+      "TypeParameters": Array [
+        Array [
+          "TType",
+          Array [
+            "TypeParameter-1",
+          ],
+        ],
+      ],
     },
     "TypeAliasDeclaration-2": Object {
       "ApiKind": "type",
@@ -260,7 +305,7 @@ Object {
           },
         ],
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "TypeAliasDeclaration-3": Object {
       "ApiKind": "type",
@@ -286,9 +331,14 @@ Object {
         "ReferenceId": "TypeLiteral-2",
         "Text": "OneCommonField1<TType>",
       },
-      "TypeParameters": Object {
-        "TType": "TypeParameter-2",
-      },
+      "TypeParameters": Array [
+        Array [
+          "TType",
+          Array [
+            "TypeParameter-2",
+          ],
+        ],
+      ],
     },
     "TypeAliasDeclaration-4": Object {
       "ApiKind": "type",
@@ -314,9 +364,14 @@ Object {
         "ReferenceId": "TypeLiteral-3",
         "Text": "OneCommonField2<TType>",
       },
-      "TypeParameters": Object {
-        "TType": "TypeParameter-3",
-      },
+      "TypeParameters": Array [
+        Array [
+          "TType",
+          Array [
+            "TypeParameter-3",
+          ],
+        ],
+      ],
     },
     "TypeAliasDeclaration-5": Object {
       "ApiKind": "type",
@@ -368,7 +423,7 @@ Object {
           },
         ],
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "TypeAliasDeclaration-6": Object {
       "ApiKind": "type",
@@ -420,16 +475,26 @@ Object {
           },
         ],
       },
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "TypeLiteral-0": Object {
       "ApiKind": "type-literal",
       "Kind": 163,
       "KindString": "TypeLiteral",
-      "Members": Object {
-        "BarName": "PropertySignature-0",
-        "FooName": "PropertySignature-1",
-      },
+      "Members": Array [
+        Array [
+          "BarName",
+          Array [
+            "PropertySignature-0",
+          ],
+        ],
+        Array [
+          "FooName",
+          Array [
+            "PropertySignature-1",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
@@ -440,9 +505,14 @@ Object {
       "ApiKind": "type-literal",
       "Kind": 163,
       "KindString": "TypeLiteral",
-      "Members": Object {
-        "BazName": "PropertySignature-2",
-      },
+      "Members": Array [
+        Array [
+          "BazName",
+          Array [
+            "PropertySignature-2",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
@@ -453,10 +523,20 @@ Object {
       "ApiKind": "type-literal",
       "Kind": 163,
       "KindString": "TypeLiteral",
-      "Members": Object {
-        "BarName": "PropertySignature-3",
-        "FooName": "PropertySignature-4",
-      },
+      "Members": Array [
+        Array [
+          "BarName",
+          Array [
+            "PropertySignature-3",
+          ],
+        ],
+        Array [
+          "FooName",
+          Array [
+            "PropertySignature-4",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
@@ -467,10 +547,20 @@ Object {
       "ApiKind": "type-literal",
       "Kind": 163,
       "KindString": "TypeLiteral",
-      "Members": Object {
-        "BarName": "PropertySignature-5",
-        "BazName": "PropertySignature-6",
-      },
+      "Members": Array [
+        Array [
+          "BarName",
+          Array [
+            "PropertySignature-5",
+          ],
+        ],
+        Array [
+          "BazName",
+          Array [
+            "PropertySignature-6",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],

--- a/tests/cases/__tests__/__snapshots__/VariableDeclaration1.test.ts.snap
+++ b/tests/cases/__tests__/__snapshots__/VariableDeclaration1.test.ts.snap
@@ -7,9 +7,14 @@ Object {
       "ApiKind": "source-file",
       "Kind": 265,
       "KindString": "SourceFile",
-      "Members": Object {
-        "FOO": "VariableDeclaration-0",
-      },
+      "Members": Array [
+        Array [
+          "FOO",
+          Array [
+            "VariableDeclaration-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],

--- a/tests/cases/__tests__/__snapshots__/VariableDeclaration2.test.ts.snap
+++ b/tests/cases/__tests__/__snapshots__/VariableDeclaration2.test.ts.snap
@@ -7,9 +7,14 @@ Object {
       "ApiKind": "source-file",
       "Kind": 265,
       "KindString": "SourceFile",
-      "Members": Object {
-        "Foo": "VariableDeclaration-0",
-      },
+      "Members": Array [
+        Array [
+          "Foo",
+          Array [
+            "VariableDeclaration-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],

--- a/tests/cases/__tests__/__snapshots__/VariableDeclaration3.test.ts.snap
+++ b/tests/cases/__tests__/__snapshots__/VariableDeclaration3.test.ts.snap
@@ -7,9 +7,14 @@ Object {
       "ApiKind": "source-file",
       "Kind": 265,
       "KindString": "SourceFile",
-      "Members": Object {
-        "z": "VariableDeclaration-0",
-      },
+      "Members": Array [
+        Array [
+          "z",
+          Array [
+            "VariableDeclaration-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],

--- a/tests/cases/__tests__/__snapshots__/VariableDeclaration4.test.ts.snap
+++ b/tests/cases/__tests__/__snapshots__/VariableDeclaration4.test.ts.snap
@@ -7,11 +7,26 @@ Object {
       "ApiKind": "source-file",
       "Kind": 265,
       "KindString": "SourceFile",
-      "Members": Object {
-        "A": "InterfaceDeclaration-0",
-        "a": "VariableDeclaration-0",
-        "z": "VariableDeclaration-1",
-      },
+      "Members": Array [
+        Array [
+          "A",
+          Array [
+            "InterfaceDeclaration-0",
+          ],
+        ],
+        Array [
+          "a",
+          Array [
+            "VariableDeclaration-0",
+          ],
+        ],
+        Array [
+          "z",
+          Array [
+            "VariableDeclaration-1",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
@@ -26,15 +41,20 @@ Object {
       "Extends": Array [],
       "Kind": 230,
       "KindString": "InterfaceDeclaration",
-      "Members": Object {
-        "b": "PropertySignature-0",
-      },
+      "Members": Array [
+        Array [
+          "b",
+          Array [
+            "PropertySignature-0",
+          ],
+        ],
+      ],
       "Metadata": Object {
         "DocumentationComment": Array [],
         "JSDocTags": Array [],
       },
       "Name": "A",
-      "TypeParameters": Object {},
+      "TypeParameters": Array [],
     },
     "PropertySignature-0": Object {
       "ApiKind": "property",


### PR DESCRIPTION
- Changed from Dictionary to Tuple to preserve items order.
- Extracted to a new function `GetItemId`. If that declaration does not exists, it adds it to registry and returns reference id.
- Added additional check in `ShouldVisitApi` if declaration's SourceFile is from external library.