### PR TITLE
Hotfix: External libraries

### DIFF
--- a/src/api-helpers.ts
+++ b/src/api-helpers.ts
@@ -130,7 +130,7 @@ export namespace ApiHelpers {
         if (externalLibraryName != null) {
             // Check if PackageName is in external packages.
             return options.ExternalPackages.
-                findIndex(x => x.toLowerCase() === externalLibraryName.toLowerCase()) !== -1;
+                findIndex(x => x === externalLibraryName) !== -1;
         } else if (!PathIsInside(declarationFileName, options.ExtractorOptions.ProjectDirectory)) {
             // If it's not external package, it should be in project directory.
             return false;

--- a/src/api-helpers.ts
+++ b/src/api-helpers.ts
@@ -121,24 +121,16 @@ export namespace ApiHelpers {
         return apiItem;
     }
 
-    export const NODE_MODULES_PACKAGE_REGEX = /\/node_modules\/(.+?)\//;
-
     export function ShouldVisit(declaration: ts.Declaration, options: ApiItemOptions): boolean {
         const declarationSourceFile = declaration.getSourceFile();
         const declarationFileName = declarationSourceFile.fileName;
 
         // External library.
-        if (options.Program.isSourceFileFromExternalLibrary(declarationSourceFile)) {
-            const match = declarationSourceFile.fileName.match(NODE_MODULES_PACKAGE_REGEX);
-            const packageName = match != null ? match[1] : undefined;
-
-            if (packageName != null) {
-                // Check if PackageName is in external packages.
-                return options.ExternalPackages.
-                    findIndex(x => x.toLowerCase() === packageName.toLowerCase()) !== -1;
-            } else {
-                return false;
-            }
+        const externalLibraryName = TsHelpers.GetSourceFileExternalLibraryLocation(declarationSourceFile, options.Program, true);
+        if (externalLibraryName != null) {
+            // Check if PackageName is in external packages.
+            return options.ExternalPackages.
+                findIndex(x => x.toLowerCase() === externalLibraryName.toLowerCase()) !== -1;
         } else if (!PathIsInside(declarationFileName, options.ExtractorOptions.ProjectDirectory)) {
             // If it's not external package, it should be in project directory.
             return false;
@@ -330,18 +322,15 @@ export namespace ApiHelpers {
     export function GetApiItemLocationDtoFromNode(node: ts.Node, options: ApiItemOptions): ApiItemLocationDto {
         const sourceFile = node.getSourceFile();
 
-        const isExternalPackage = options.Program.isSourceFileFromExternalLibrary(sourceFile);
         const position = sourceFile.getLineAndCharacterOfPosition(node.getStart());
         const fileNamePath = path.relative(options.ExtractorOptions.ProjectDirectory, sourceFile.fileName);
         let fileName = StandardizeRelativePath(fileNamePath, options);
 
-        if (isExternalPackage) {
-            const packageFullPath = fileName.match(/\/node_modules\/(.+?)$/);
-
-            if (packageFullPath != null) {
-                const [, packagePath] = packageFullPath;
-                fileName = packagePath;
-            }
+        // Resolve package location if source file from external library.
+        const externalPackagePath = TsHelpers.GetSourceFileExternalLibraryLocation(sourceFile, options.Program);
+        const isExternalPackage = externalPackagePath != null;
+        if (externalPackagePath != null) {
+            fileName = externalPackagePath;
         }
 
         return {

--- a/src/ts-helpers.ts
+++ b/src/ts-helpers.ts
@@ -130,4 +130,35 @@ export namespace TsHelpers {
     export function IsNodeSynthesized(node: ts.Node): boolean {
         return Boolean(node.flags & ts.NodeFlags.Synthesized);
     }
+
+    export const NODE_MODULES_PACKAGE_REGEX = /\/node_modules\/(.+?)\/.*/;
+
+    /**
+     * @param onlyName if true, returns only package name.
+     */
+    export function GetSourceFileExternalLibraryLocation(
+        sourceFile: ts.SourceFile,
+        program: ts.Program,
+        onlyName?: boolean
+    ): string | undefined {
+        const externalLibraryMatch = sourceFile.fileName.match(NODE_MODULES_PACKAGE_REGEX);
+
+        if (program.isSourceFileFromExternalLibrary(sourceFile) || externalLibraryMatch != null) {
+            if (externalLibraryMatch != null) {
+                if (onlyName) {
+                    // returns `typescript`
+                    return externalLibraryMatch[1];
+                } else {
+                    // Returns `typescript/lib/lib.es5.d.ts`
+                    return externalLibraryMatch[0].replace("/node_modules/", "");
+                }
+            }
+        }
+
+        return undefined;
+    }
+
+    export function IsSourceFileFromExternalPackage(sourceFile: ts.SourceFile, program: ts.Program): boolean {
+        return GetSourceFileExternalLibraryLocation(sourceFile, program) != null;
+    }
 }


### PR DESCRIPTION
Filenames that are in `./node_modules/*` path considered as external packages.
__Example:__
 `./node_modules/typescript/libs/lib.es5.d.ts`.

https://github.com/SimplrJS/ts-docs-gen/issues/34